### PR TITLE
[feat] Optional force redirect ssl

### DIFF
--- a/optscale-deploy/optscale/templates/ingress.yaml
+++ b/optscale-deploy/optscale/templates/ingress.yaml
@@ -11,8 +11,10 @@ metadata:
     nginx.ingress.kubernetes.io/client-body-buffer-size:  "512m"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
+    {{ if .Values.ssl.force_redirect }}
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    {{ end }}
   name: optscale
   namespace: default
 spec:

--- a/optscale-deploy/optscale/values.yaml
+++ b/optscale-deploy/optscale/values.yaml
@@ -980,7 +980,14 @@ cleanelkdb:
 # Used when --update-only runkube flag is set
 skip_config_update: false
 
-# list of overlays used by runkube to start OptScale (necessary to use proper defaults when adding new keys on update)
+# set to true to deploy HA Optscale on multi-master k8s cluster (tested with 3 nodes)
+ha: false
+
+ssl:
+  # set to false to not force ssl redirect on k8s ingress
+  force_redirect: true
+
+# list of overlays used by runkube to start Optscale (necessary to use proper defaults when adding new keys on update)
 overlay_list: ""
 
 # k8s cluster domain


### PR DESCRIPTION
Hello,

In some case, we do not want to force ssl redirect on the nginx ingress
Eg: LB in front managing ssl.

`< user https > <front reverse proxy ssl> <ingress k8s http>`

So, I added this option, to keep the possibility of having ssl on the nginx ingress but avoiding ssl redirection loop in case of frontend managing it.

Thomas.
