### PR TITLE
fix: add missing google_oauth_client_secret [#65]

### DIFF
--- a/optscale-deploy/optscale/templates/auth.yaml
+++ b/optscale-deploy/optscale/templates/auth.yaml
@@ -61,6 +61,8 @@ spec:
           value: {{ .Values.etcd.service.externalPort | quote }}
         - name: GOOGLE_OAUTH_CLIENT_ID
           value: {{ $config.google_oauth_client_id | quote }}
+        - name: GOOGLE_OAUTH_CLIENT_SECRET
+          value: {{ $config.google_oauth_client_secret | quote }}
         - name: MICROSOFT_OAUTH_CLIENT_ID
           value: {{ $config.microsoft_oauth_client_id | quote }}
 {{ include "ready_probe" $config | indent 8 }}

--- a/optscale-deploy/overlay/user_template.yml
+++ b/optscale-deploy/overlay/user_template.yml
@@ -85,6 +85,7 @@ encryption_key: fffffxdddeadb33f
 # - https://portal.azure.com/ to see registered origins for the Microsoft OAuth client"
 auth:
   google_oauth_client_id: ""
+  google_oauth_client_secret: ""
   microsoft_oauth_client_id: ""
 
 ngui:


### PR DESCRIPTION
Hello,

Add missing GOOGLE_OAUTH_CLIENT_SECRET to be able to use google auth.

https://github.com/hystax/optscale/blob/integration/auth/auth_server/controllers/signin.py#L44

Fix for: https://github.com/hystax/optscale/issues/65

Thomas.