### PR TITLE
fix: take properly in charge version optscale runkube.py

### DIFF
--- a/optscale-deploy/runkube.py
+++ b/optscale-deploy/runkube.py
@@ -158,7 +158,7 @@ class Runkube:
         docker_cl = self.get_docker_cl(self.master_ip)
         images = {}
         for service in self.versions_info['images']:
-            image = docker_cl.images.get('{}:local'.format(service))
+            image = docker_cl.images.get('{}:{}'.format(service, self.version))
             images[service] = image.id
         LOG.debug("Image ids map: %s", images)
         return images


### PR DESCRIPTION
Hello,

The new version of runkube.py do not take in charge properly de --version requirement when the tag defined in "build.sh" is different than "local" on a local build.

Issue: it's hardcoded.

Before:
```bash
opt/optscale/optscale-deploy$ ./runkube.py --update-only --dregistry 127.0.0.1 --no-pull -- preligens thomas

11:31:25.854: Getting old overlay list
11:31:26.140: Generating base overlay...
Traceback (most recent call last):
  File "/home/ubuntu/.local/lib/python3.8/site-packages/docker/api/client.py", line 223, in _raise_for_status
    response.raise_for_status()
  File "/home/ubuntu/.local/lib/python3.8/site-packages/requests/models.py", line 1021, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 404 Client Error: Not Found for url: http://10.130.1.3:2376/v1.35/images/bi_scheduler:local/json

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "./runkube.py", line 430, in <module>
    acr.start(args.check, args.update_only)
  File "./runkube.py", line 317, in start
    overlays.append(self.generate_base_overlay(update))
  File "./runkube.py", line 174, in generate_base_overlay
    for name, image_id in self.get_image_id_map().items():
  File "./runkube.py", line 161, in get_image_id_map
    image = docker_cl.images.get('{}:local'.format(service))
  File "/home/ubuntu/.local/lib/python3.8/site-packages/docker/models/images.py", line 212, in get
    return self.prepare_model(self.client.api.inspect_image(name))
  File "/home/ubuntu/.local/lib/python3.8/site-packages/docker/utils/decorators.py", line 19, in wrapped
    return f(self, resource_id, *args, **kwargs)
  File "/home/ubuntu/.local/lib/python3.8/site-packages/docker/api/image.py", line 240, in inspect_image
    return self._result(
  File "/home/ubuntu/.local/lib/python3.8/site-packages/docker/api/client.py", line 229, in _result
    self._raise_for_status(response)
  File "/home/ubuntu/.local/lib/python3.8/site-packages/docker/api/client.py", line 225, in _raise_for_status
    raise create_api_error_from_http_exception(e)
  File "/home/ubuntu/.local/lib/python3.8/site-packages/docker/errors.py", line 31, in create_api_error_from_http_exception
    raise cls(e, response=response, explanation=explanation)
docker.errors.ImageNotFound: 404 Client Error: Not Found ("no such image: bi_scheduler:local: No such image: bi_scheduler:local")
```

```
 docker images |grep bi_sc
bi_scheduler                                            thomas                                     cf0b07e32881   16 hours ago    138MB
```

Thomas.
