### PR TITLE
Pull request update/241001

### DIFF
--- a/ngui/server/graphql/resolvers/restapi.generated.ts
+++ b/ngui/server/graphql/resolvers/restapi.generated.ts
@@ -54,6 +54,7 @@ export type AwsConfig = {
   linked?: Maybe<Scalars['Boolean']['output']>;
   region_name?: Maybe<Scalars['String']['output']>;
   report_name?: Maybe<Scalars['String']['output']>;
+  use_edp_discount?: Maybe<Scalars['Boolean']['output']>;
 };
 
 export type AwsDataSource = DataSourceInterface & {
@@ -87,6 +88,7 @@ export type AwsRootConfigInput = {
   cur_version?: InputMaybe<Scalars['Int']['input']>;
   report_name?: InputMaybe<Scalars['String']['input']>;
   secret_access_key: Scalars['String']['input'];
+  use_edp_discount?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type AzureSubscriptionConfig = {
@@ -592,6 +594,7 @@ export type AwsConfigResolvers<ContextType = any, ParentType extends ResolversPa
   linked?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   region_name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   report_name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  use_edp_discount?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 

--- a/ngui/server/graphql/schemas/restapi.graphql
+++ b/ngui/server/graphql/schemas/restapi.graphql
@@ -53,6 +53,7 @@ interface DataSourceInterface {
 type AwsConfig {
   access_key_id: String
   linked: Boolean
+  use_edp_discount: Boolean
   cur_version: Int
   bucket_name: String
   bucket_prefix: String
@@ -271,6 +272,7 @@ input DataSourceRequestParams {
 input AwsRootConfigInput {
   access_key_id: String!
   secret_access_key: String!
+  use_edp_discount: Boolean
   cur_version: Int
   bucket_name: String
   bucket_prefix: String

--- a/ngui/ui/src/components/DataSourceCredentialFields/AwsRootUseAwsEdpDiscount/AwsRootUseAwsEdpDiscount.tsx
+++ b/ngui/ui/src/components/DataSourceCredentialFields/AwsRootUseAwsEdpDiscount/AwsRootUseAwsEdpDiscount.tsx
@@ -1,0 +1,18 @@
+import { FormattedMessage } from "react-intl";
+import { Checkbox } from "components/forms/common/fields";
+import QuestionMark from "components/QuestionMark";
+
+export const FIELD_NAMES = Object.freeze({
+  USE_EDP_DISCOUNT: "useEdpDiscount"
+});
+
+const AwsRootUseAwsEdpDiscount = () => (
+  <Checkbox
+    name={FIELD_NAMES.USE_EDP_DISCOUNT}
+    label={<FormattedMessage id="useAwsEdpDiscount" />}
+    defaultValue={false}
+    adornment={<QuestionMark tooltipText={<FormattedMessage id="useAwsEdpDiscountDescription" />} />}
+  />
+);
+
+export default AwsRootUseAwsEdpDiscount;

--- a/ngui/ui/src/components/DataSourceCredentialFields/AwsRootUseAwsEdpDiscount/index.ts
+++ b/ngui/ui/src/components/DataSourceCredentialFields/AwsRootUseAwsEdpDiscount/index.ts
@@ -1,0 +1,4 @@
+import AwsRootUseAwsEdpDiscount, { FIELD_NAMES } from "./AwsRootUseAwsEdpDiscount";
+
+export { FIELD_NAMES };
+export default AwsRootUseAwsEdpDiscount;

--- a/ngui/ui/src/components/DataSourceCredentialFields/index.ts
+++ b/ngui/ui/src/components/DataSourceCredentialFields/index.ts
@@ -3,6 +3,7 @@ import AwsLinkedCredentials, { FIELD_NAMES as AWS_LINKED_CREDENTIALS_FIELD_NAMES
 import AwsRootBillingBucket, { FIELD_NAMES as AWS_ROOT_BILLING_BUCKET_FIELD_NAMES } from "./AwsRootBillingBucket";
 import AwsRootCredentials, { FIELD_NAMES as AWS_ROOT_CREDENTIALS_FIELD_NAMES } from "./AwsRootCredentials";
 import AwsRootExportType, { FIELD_NAMES as AWS_ROOT_EXPORT_TYPE_FIELD_NAMES } from "./AwsRootExportType";
+import AwsRootUseAwsEdpDiscount, { FIELD_NAMES as AWS_ROOT_USE_AWS_EDP_DISCOUNT_FIELD_NAMES } from "./AwsRootUseAwsEdpDiscount";
 import AzureSubscriptionCredentials, {
   FIELD_NAMES as AZURE_SUBSCRIPTION_CREDENTIALS_FIELD_NAMES
 } from "./AzureSubscriptionCredentials";
@@ -19,6 +20,8 @@ export {
   AWS_ROOT_BILLING_BUCKET_FIELD_NAMES,
   AwsRootExportType,
   AWS_ROOT_EXPORT_TYPE_FIELD_NAMES,
+  AwsRootUseAwsEdpDiscount,
+  AWS_ROOT_USE_AWS_EDP_DISCOUNT_FIELD_NAMES,
   AwsLinkedCredentials,
   AWS_LINKED_CREDENTIALS_FIELD_NAMES,
   AzureTenantCredentials,

--- a/ngui/ui/src/components/DataSourceDetails/Properties/AwsProperties.tsx
+++ b/ngui/ui/src/components/DataSourceDetails/Properties/AwsProperties.tsx
@@ -11,6 +11,7 @@ type AwsPropertiesProps = {
     linked: boolean;
     report_name: string;
     cur_version?: 1 | 2;
+    use_edp_discount?: boolean;
   };
 };
 
@@ -21,7 +22,8 @@ const AwsProperties = ({ accountId, config }: AwsPropertiesProps) => {
     bucket_prefix: buckerPrefix,
     linked,
     cur_version: curVersion,
-    report_name: reportName
+    report_name: reportName,
+    use_edp_discount: useEdpDiscount
   } = config;
 
   return (
@@ -56,6 +58,11 @@ const AwsProperties = ({ accountId, config }: AwsPropertiesProps) => {
       ) : null}
       {!linked && (
         <>
+          <KeyValueLabel
+            keyMessageId="useAwsEdpDiscount"
+            value={<FormattedMessage id={useEdpDiscount ? "yes" : "no"} />}
+            dataTestIds={{ key: "p_use_edp_discount_key", value: "p_use_edp_discount_value" }}
+          />
           <KeyValueLabel
             keyMessageId="exportName"
             value={reportName}

--- a/ngui/ui/src/components/Resource/Resource.tsx
+++ b/ngui/ui/src/components/Resource/Resource.tsx
@@ -249,7 +249,7 @@ const Resource = ({ resource, isGetResourceLoading, patchResource, isLoadingPatc
         onClick: () => setActiveTab(RECOMMENDATIONS_TAB),
         tooltip: {
           show: true,
-          messageId: "recommendations",
+          messageId: "seeAllRecommendations",
           placement: "top"
         }
       },

--- a/ngui/ui/src/components/forms/ConnectCloudAccountForm/ConnectCloudAccountForm.tsx
+++ b/ngui/ui/src/components/forms/ConnectCloudAccountForm/ConnectCloudAccountForm.tsx
@@ -18,7 +18,8 @@ import {
   AWS_ROOT_CREDENTIALS_FIELD_NAMES,
   AWS_ROOT_BILLING_BUCKET_FIELD_NAMES,
   AWS_ROOT_EXPORT_TYPE_FIELD_NAMES,
-  AWS_LINKED_CREDENTIALS_FIELD_NAMES
+  AWS_LINKED_CREDENTIALS_FIELD_NAMES,
+  AWS_ROOT_USE_AWS_EDP_DISCOUNT_FIELD_NAMES
 } from "components/DataSourceCredentialFields";
 import FormButtonsWrapper from "components/FormButtonsWrapper";
 import ModeWrapper from "components/ModeWrapper";
@@ -108,11 +109,12 @@ const getAwsParameters = (formData) => {
           config_scheme: formData[AWS_ROOT_INPUTS_FIELD_NAMES.CONFIG_SCHEME]
         };
   return {
-    name: formData.name,
+    name: formData[DATA_SOURCE_NAME_FIELD_NAME],
     type: AWS_CNR,
     config: {
       access_key_id: formData[AWS_ROOT_CREDENTIALS_FIELD_NAMES.ACCESS_KEY_ID],
       secret_access_key: formData[AWS_ROOT_CREDENTIALS_FIELD_NAMES.SECRET_ACCESS_KEY],
+      use_edp_discount: formData[AWS_ROOT_USE_AWS_EDP_DISCOUNT_FIELD_NAMES.USE_EDP_DISCOUNT],
       linked: false,
       cur_version: Number(formData[AWS_ROOT_EXPORT_TYPE_FIELD_NAMES.CUR_VERSION]),
       ...getConfigSchemeParameters()

--- a/ngui/ui/src/components/forms/ConnectCloudAccountForm/FormElements/ConnectionFields.tsx
+++ b/ngui/ui/src/components/forms/ConnectCloudAccountForm/FormElements/ConnectionFields.tsx
@@ -13,7 +13,8 @@ import {
   KubernetesCredentials,
   DatabricksCredentials,
   AwsRootBillingBucket,
-  AwsRootExportType
+  AwsRootExportType,
+  AwsRootUseAwsEdpDiscount
 } from "components/DataSourceCredentialFields";
 import { RadioGroup } from "components/forms/common/fields";
 import {
@@ -54,6 +55,7 @@ const AwsRootInputs = () => (
       return (
         <>
           <AwsRootCredentials />
+          <AwsRootUseAwsEdpDiscount />
           <AwsRootExportType />
           <SwitchField
             name={AWS_ROOT_INPUTS_FIELD_NAMES.IS_FIND_REPORT}

--- a/ngui/ui/src/components/forms/UpdateDataSourceCredentialsForm/FormElements/CredentialInputs.tsx
+++ b/ngui/ui/src/components/forms/UpdateDataSourceCredentialsForm/FormElements/CredentialInputs.tsx
@@ -16,7 +16,8 @@ import {
   AwsLinkedCredentials,
   AwsRootCredentials,
   AwsRootBillingBucket,
-  AwsRootExportType
+  AwsRootExportType,
+  AwsRootUseAwsEdpDiscount
 } from "components/DataSourceCredentialFields";
 import { Switch } from "components/forms/common/fields";
 import {
@@ -63,6 +64,7 @@ const CredentialInputs = ({ type, config }) => {
       ) : (
         <>
           <AwsRootCredentials />
+          <AwsRootUseAwsEdpDiscount />
           <CostAndUsageReport />
         </>
       );

--- a/ngui/ui/src/components/forms/UpdateDataSourceCredentialsForm/UpdateDataSourceCredentialsForm.tsx
+++ b/ngui/ui/src/components/forms/UpdateDataSourceCredentialsForm/UpdateDataSourceCredentialsForm.tsx
@@ -237,6 +237,7 @@ const getConfig = (type, config) => {
                 [AWS_ROOT_CREDENTIALS_FIELD_NAMES.ACCESS_KEY_ID]: config.access_key_id,
                 [AWS_ROOT_CREDENTIALS_FIELD_NAMES.SECRET_ACCESS_KEY]: "",
                 [AWS_ROOT_UPDATE_DATA_EXPORT_PARAMETERS]: false,
+                [AWS_ROOT_USE_AWS_EDP_DISCOUNT_FIELD_NAMES.USE_EDP_DISCOUNT]: config.use_edp_discount,
                 [AWS_ROOT_EXPORT_TYPE_FIELD_NAMES.CUR_VERSION]: config.cur_version ?? AWS_ROOT_CONNECT_CUR_VERSION.CUR_2,
                 [AWS_ROOT_BILLING_BUCKET_FIELD_NAMES.BUCKET_NAME]: config.bucket_name,
                 [AWS_ROOT_BILLING_BUCKET_FIELD_NAMES.EXPORT_NAME]: config.report_name,

--- a/ngui/ui/src/components/forms/UpdateDataSourceCredentialsForm/UpdateDataSourceCredentialsForm.tsx
+++ b/ngui/ui/src/components/forms/UpdateDataSourceCredentialsForm/UpdateDataSourceCredentialsForm.tsx
@@ -264,7 +264,11 @@ const getConfig = (type, config) => {
                         bucket_prefix: formData[AWS_ROOT_BILLING_BUCKET_FIELD_NAMES.BUCKET_PREFIX]
                       }
                     : {
-                        cur_version: config.cur_version,
+                        /**
+                         * Data sources that were created before the introduction of the new data export parameters
+                         * may not have the cur_version field set, so we need to pass it as undefined to avoid sending it to the backend
+                         */
+                        cur_version: config.cur_version ?? undefined,
                         bucket_name: config.bucket_name,
                         report_name: config.report_name,
                         bucket_prefix: config.bucket_prefix

--- a/ngui/ui/src/components/forms/UpdateDataSourceCredentialsForm/UpdateDataSourceCredentialsForm.tsx
+++ b/ngui/ui/src/components/forms/UpdateDataSourceCredentialsForm/UpdateDataSourceCredentialsForm.tsx
@@ -14,7 +14,8 @@ import {
   AWS_LINKED_CREDENTIALS_FIELD_NAMES,
   AWS_ROOT_CREDENTIALS_FIELD_NAMES,
   AWS_ROOT_BILLING_BUCKET_FIELD_NAMES,
-  AWS_ROOT_EXPORT_TYPE_FIELD_NAMES
+  AWS_ROOT_EXPORT_TYPE_FIELD_NAMES,
+  AWS_ROOT_USE_AWS_EDP_DISCOUNT_FIELD_NAMES
 } from "components/DataSourceCredentialFields";
 import FormButtonsWrapper from "components/FormButtonsWrapper";
 import InlineSeverityAlert from "components/InlineSeverityAlert";
@@ -253,6 +254,7 @@ const getConfig = (type, config) => {
                   access_key_id: formData[AWS_ROOT_CREDENTIALS_FIELD_NAMES.ACCESS_KEY_ID],
                   secret_access_key: formData[AWS_ROOT_CREDENTIALS_FIELD_NAMES.SECRET_ACCESS_KEY],
                   config_scheme: AWS_ROOT_CONNECT_CONFIG_SCHEMES.BUCKET_ONLY,
+                  use_edp_discount: formData[AWS_ROOT_USE_AWS_EDP_DISCOUNT_FIELD_NAMES.USE_EDP_DISCOUNT],
                   ...(formData[AWS_ROOT_UPDATE_DATA_EXPORT_PARAMETERS]
                     ? {
                         cur_version: Number(formData[AWS_ROOT_EXPORT_TYPE_FIELD_NAMES.CUR_VERSION]),

--- a/ngui/ui/src/components/forms/UpdateDataSourceCredentialsForm/UpdateDataSourceCredentialsForm.tsx
+++ b/ngui/ui/src/components/forms/UpdateDataSourceCredentialsForm/UpdateDataSourceCredentialsForm.tsx
@@ -237,7 +237,7 @@ const getConfig = (type, config) => {
                 [AWS_ROOT_CREDENTIALS_FIELD_NAMES.ACCESS_KEY_ID]: config.access_key_id,
                 [AWS_ROOT_CREDENTIALS_FIELD_NAMES.SECRET_ACCESS_KEY]: "",
                 [AWS_ROOT_UPDATE_DATA_EXPORT_PARAMETERS]: false,
-                [AWS_ROOT_USE_AWS_EDP_DISCOUNT_FIELD_NAMES.USE_EDP_DISCOUNT]: config.use_edp_discount,
+                [AWS_ROOT_USE_AWS_EDP_DISCOUNT_FIELD_NAMES.USE_EDP_DISCOUNT]: config.use_edp_discount ?? false,
                 [AWS_ROOT_EXPORT_TYPE_FIELD_NAMES.CUR_VERSION]: config.cur_version ?? AWS_ROOT_CONNECT_CUR_VERSION.CUR_2,
                 [AWS_ROOT_BILLING_BUCKET_FIELD_NAMES.BUCKET_NAME]: config.bucket_name,
                 [AWS_ROOT_BILLING_BUCKET_FIELD_NAMES.EXPORT_NAME]: config.report_name,

--- a/ngui/ui/src/components/forms/common/fields/Checkbox.tsx
+++ b/ngui/ui/src/components/forms/common/fields/Checkbox.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from "react";
+import { Box } from "@mui/material";
 import MuiCheckbox from "@mui/material/Checkbox";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import { useFormContext, Controller } from "react-hook-form";
@@ -7,11 +8,13 @@ import CheckboxLoader from "components/CheckboxLoader";
 type CheckboxProps = {
   name: string;
   label: ReactNode;
+  defaultValue?: boolean;
+  adornment?: ReactNode;
   disabled?: boolean;
   isLoading?: boolean;
 };
 
-const Checkbox = ({ name, label, disabled = false, isLoading = false }: CheckboxProps) => {
+const Checkbox = ({ name, label, defaultValue, adornment, disabled = false, isLoading = false }: CheckboxProps) => {
   const { control } = useFormContext();
 
   return isLoading ? (
@@ -22,6 +25,7 @@ const Checkbox = ({ name, label, disabled = false, isLoading = false }: Checkbox
         <Controller
           name={name}
           control={control}
+          defaultValue={defaultValue}
           render={({ field: { value, onChange, ...rest } }) => (
             <MuiCheckbox
               data-test-id={`${name}-checkbox`}
@@ -33,7 +37,12 @@ const Checkbox = ({ name, label, disabled = false, isLoading = false }: Checkbox
           )}
         />
       }
-      label={<span data-test-id={`${name}-checkbox-label`}>{label}</span>}
+      label={
+        <Box data-test-id={`${name}-checkbox-label`} display="flex" alignItems="center">
+          {label}
+          {adornment}
+        </Box>
+      }
     />
   );
 };

--- a/ngui/ui/src/containers/ExpensesSummaryContainer/ExpensesSummaryContainer.tsx
+++ b/ngui/ui/src/containers/ExpensesSummaryContainer/ExpensesSummaryContainer.tsx
@@ -51,7 +51,7 @@ const ExpensesSummaryContainer = ({ requestParams }) => {
         link: RECOMMENDATIONS,
         tooltip: {
           show: true,
-          messageId: "recommendations",
+          messageId: "seeAllRecommendations",
           placement: "top"
         }
       },

--- a/ngui/ui/src/graphql/api/restapi/queries/restapi.queries.ts
+++ b/ngui/ui/src/graphql/api/restapi/queries/restapi.queries.ts
@@ -36,6 +36,7 @@ const GET_DATA_SOURCE = gql`
         config {
           access_key_id
           linked
+          use_edp_discount
           cur_version
           bucket_name
           bucket_prefix

--- a/ngui/ui/src/translations/en-US/app.json
+++ b/ngui/ui/src/translations/en-US/app.json
@@ -2273,6 +2273,8 @@
   "upload": "Upload",
   "url": "URL",
   "usage": "Usage",
+  "useAwsEdpDiscount": "Use AWS Enterprise Discount Program (EDP)",
+  "useAwsEdpDiscountDescription": "Use this option to apply any available discounts under your AWS Enterprise Discount Program (EDP) agreement.",
   "used": "Used",
   "usedAliases": "Used aliases",
   "user": "User",

--- a/tools/cloud_adapter/clouds/aws.py
+++ b/tools/cloud_adapter/clouds/aws.py
@@ -755,10 +755,13 @@ class Aws(S3CloudMixin):
             }
             destination = export['DestinationConfigurations']['S3Destination']
             s3_conf = destination['S3OutputConfigurations']
+            cost_and_usage_report = export['DataQuery'][
+                'TableConfigurations'].get('COST_AND_USAGE_REPORT')
+            if not cost_and_usage_report:
+                continue
             result.append({
                 'ReportName': export['Name'],
-                'TimeUnit': export['DataQuery']['TableConfigurations'][
-                    'COST_AND_USAGE_REPORT']['TIME_GRANULARITY'],
+                'TimeUnit': cost_and_usage_report['TIME_GRANULARITY'],
                 'Format': format_map.get(s3_conf['Format']) or s3_conf['Format'],
                 'Compression': format_map.get(
                     s3_conf['Compression']) or s3_conf['Compression'],


### PR DESCRIPTION
09ce832e OS-7880. Add a default value for the AWS_ROOT_USE_AWS_EDP_DISCOUNT_FIELD_NAMES.USE_EDP_DISCOUNT field
30dcd467 OS-7880. Handle undefined cur_version
3f46834d OS-7835: Fix the default state of the 'use_edp_discount' checkbox on the 'Update Credentials' form
1652e22b OS-7835. Add support for use_edp_discount parameter for AWS root data sources
edc4240b OS-7878. Fixed 500 error on AWS not usual reports
ca1974dc OS-2731. Update tooltip message for Possible monthly savings card
