### PR TITLE
fix: raise RuntimeError(f'Could not pull image {full_image_name} and fetch last pushed tag')

### DIFF
--- a/optscale-deploy/runkube.py
+++ b/optscale-deploy/runkube.py
@@ -4,6 +4,7 @@ import argparse
 import base64
 import json
 import logging
+import requests
 
 import os
 import time
@@ -142,13 +143,35 @@ class Runkube:
             }
         return self._versions_info
 
+    def _get_image_tags(self, repository):
+        """Fetch all tags of a Docker Hub repository."""
+        url = f"https://hub.docker.com/v2/repositories/hystax/{repository}/tags"
+        tags = []
+
+        while url:
+            response = requests.get(url)
+            data = response.json()
+            tags.extend([tag["name"] for tag in data.get("results", [])])
+            url = data.get("next")  
+        
+        return tags
+
     def _pull_image(self, ctrd_cl, image_name, tag, auth_config):
-        full_image_name = os.path.join(self.dregistry, image_name)
-        LOG.info("Pulling image %s with tag %s", full_image_name, tag)
-        ctrd_cl.image.pull('{}:{}'.format(full_image_name, tag))
-        image = ctrd_cl.image.inspect('{}:{}'.format(full_image_name, tag)).id
-        LOG.debug("Pulled image with id %s", image)
-        return image
+        try:
+            full_image_name = os.path.join(self.dregistry, image_name)
+            LOG.info("Pulling image %s with tag %s", full_image_name, tag)
+            ctrd_cl.image.pull('{}:{}'.format(full_image_name, tag))
+            image = ctrd_cl.image.inspect('{}:{}'.format(full_image_name, tag)).id
+            LOG.debug("Pulled image with id %s", image)
+            return image
+        except:
+            tags = self._get_image_tags(image_name)
+            LATEST_TAG = tags[0]
+
+            ctrd_cl.image.pull('{}:{}'.format(full_image_name, LATEST_TAG))
+            image = ctrd_cl.image.inspect('{}:{}'.format(full_image_name, LATEST_TAG)).id
+            LOG.debug("Pulled image with id %s", image)
+            return image
 
     def pull_images(self, ctrd_cl):
         LOG.debug("Logging into container registry %s", self.dregistry)


### PR DESCRIPTION
Fix raise exception because can't find last pushed tag

## Description

**Context:** 
I run `./runkube.py --with-elk -o overlay/user_template.yml -- custom local` and get following error.

```
raise RuntimeError(f"Could not pull image {full_image_name} and fetch last pushed tag")
```
![image](https://github.com/user-attachments/assets/e92c52ac-6c6b-4651-8419-d04a85a74d47)

**Reason:**
Script pull the image with tag local, in case tag does not exist it through above error. 


## Related issue number

This PR is to resolve issue at - #563

## Special notes

The PR add few lines of code with addition of `_get_image_tags` inside catch exception for `_pull_image` method. If _pull_image method can't find the tag map with the tag user input, then get the last pushed tag to pull image.

## Checklist

* [ ] The pull request title is a good summary of the changes
* [ ] Unit tests for the changes exist
* [ ] New and existing unit tests pass locally