### PR TITLE
Fix: Fix default profile for clickhouse

### DIFF
--- a/optscale-deploy/optscale/templates/clickhouse/config.tpl
+++ b/optscale-deploy/optscale/templates/clickhouse/config.tpl
@@ -24,7 +24,7 @@
     <mark_cache_size>5368709120</mark_cache_size>
     <path>/var/lib/clickhouse/</path>
     <tmp_path>/var/lib/clickhouse/tmp/</tmp_path>
-    <default_profile>{{ .Values.clickhouse.db.user }}</default_profile>
+    <default_profile>default</default_profile>
     <default_database>{{ .Values.clickhouse.db.name }}</default_database>
     <zookeeper incl="zookeeper-servers" optional="true" />
     <macros incl="macros" optional="true" />


### PR DESCRIPTION
## Description

Now if you want to change username for clickhouse you need also manually create a profile with the same name as user. 
This PR fixes this, but in ugly way.
The better solution is to add `profile` for clickhouse, inside `values.yaml`, and add profile creation step in the `init_container`. 

## Checklist

* [x] The pull request title is a good summary of the changes
* [x] Unit tests for the changes exist
* [x] New and existing unit tests pass locally