### PR TITLE
MPT-9777 get_bucket_location returns EU instead of eu-west-1 for some…

### DIFF
--- a/gemini/gemini_worker/duplicate_object_finder/aws/object_enumerator.py
+++ b/gemini/gemini_worker/duplicate_object_finder/aws/object_enumerator.py
@@ -54,8 +54,18 @@ class AWSObjectEnumerator:
 
             # Buckets in region us-east-1 have a LocationConstraint of None
             # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/get_bucket_location.html
-            region = response.get("LocationConstraint") or "us-east-1"
-            LOG.info(f"Processing bucket {bucket} in {region}")
+
+            location_constraint = response.get("LocationConstraint")
+
+            if not location_constraint:
+                # LocationConstraint will be None if bucket is located in us-east-1
+                region = 'us-east-1'
+            elif location_constraint.lower() == 'eu':
+                # LocationConstraint will be EU if bucket is located in eu-west-1
+                region = 'eu-west-1'
+            else:
+                region = location_constraint
+                LOG.info(f"Processing bucket {bucket} in {region}")
 
             paginator = self._client_factory.create_client(
                 region).get_paginator("list_objects_v2")

--- a/tools/cloud_adapter/clouds/aws.py
+++ b/tools/cloud_adapter/clouds/aws.py
@@ -453,8 +453,14 @@ class Aws(S3CloudMixin):
 
     def discover_bucket_info(self, bucket_name):
         region_info = self.s3.get_bucket_location(Bucket=bucket_name)
-        # LocationConstraint will be None if bucket is located in us-east-1
-        region = region_info['LocationConstraint'] or 'us-east-1'
+        if not region_info['LocationConstraint']:
+            # LocationConstraint will be None if bucket is located in us-east-1
+            region = 'us-east-1'
+        elif region_info['LocationConstraint'].lower() == 'eu':
+            # LocationConstraint will be EU if bucket is located in eu-west-1
+            region = 'eu-west-1'
+        else:
+            region = region_info['LocationConstraint']
 
         # get_bucket_tagging fails for eu-south-1 if region is not set
         # explicitly, so we find region first and initialize client for


### PR DESCRIPTION
## Description

The value `EU` for `LocationConstraint` was used historically by AWS to refer to the eu-west-1 (Ireland) region.
It is now deprecated in favor of explicitly named regions like eu-west-1, eu-central-1, etc.


## Related issue number
.

## Special notes
.

## Checklist

* [X] The pull request title is a good summary of the changes
* [ ] Unit tests for the changes exist
* [X] New and existing unit tests pass locally