### PR TITLE
MPT-11683 support cert-manager for ssl certificate management

### DIFF
--- a/documentation/apply_SSL_certificate.md
+++ b/documentation/apply_SSL_certificate.md
@@ -14,3 +14,20 @@ and restart all NGINX Kubernetes pods:
 ```
 kubectl delete pod $(kubectl get pod | awk '/ngingress-nginx-ingress-controller/ {print $1}')
 ```
+
+# How to use **cert-manager** for managing the SSL certificate lifecycle
+
+You can use [cert-manager](https://cert-manager.io) to manage the SSL certificate enrollment and renewal.
+
+The installation of **cert-manager** and the setup of an Issuer is out of the scope of this guide.
+Please read the [cert-manager documentation](https://cert-manager.io/docs/getting-started/).
+
+To setup Optscale to use cert-manager:
+
+Edit file with overlay - [optscale-deploy/overlay/user_template.yml](optscale-deploy/overlay/user_template.yml); see comments in overlay file for guidance.
+
+Apply the changes using `runkube.py`:
+
+```
+./runkube.py --with-elk  -o overlay/user_template.yml -- <deployment name> <version>
+```

--- a/optscale-deploy/optscale/templates/ingress.yaml
+++ b/optscale-deploy/optscale/templates/ingress.yaml
@@ -10,10 +10,13 @@ metadata:
     nginx.ingress.kubernetes.io/client-body-buffer-size:  "512m"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
-    {{ if .Values.ssl.force_redirect }}
+    {{- if .Values.ssl.force_redirect }}
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
-    {{ end }}
+    {{- end }}
+    {{- if .Values.ssl.cert_manager.enabled }}
+    cert-manager.io/{{ .Values.ssl.cert_manager.issuer_type }}: {{ .Values.ssl.cert_manager.issuer | quote }}
+    {{- end }}
   name: optscale
   namespace: default
 spec:
@@ -105,5 +108,12 @@ spec:
               number: {{ .Values.diproxy.service.externalPort }}
         path: /storage
         pathType: Prefix
+{{- if .Values.public_ip }}
+  host: {{ .Values.public_ip }}
+{{- end }}
   tls:
-  - secretName: defaultcert
+  - secretName: {{ .Values.ssl.certificate_name }}
+{{- if .Values.public_ip }}
+    hosts:
+    - {{ .Values.public_ip }}
+{{- end }}

--- a/optscale-deploy/optscale/values.yaml
+++ b/optscale-deploy/optscale/values.yaml
@@ -929,6 +929,11 @@ skip_config_update: false
 ssl:
   # set to false to not force ssl redirect on k8s ingress
   force_redirect: true
+  certificate_name: defaultcert
+  cert_manager:
+    enabled: false
+    issuer_type: issuer
+    issuer:
 
 # list of overlays used by runkube to start Optscale (necessary to use proper defaults when adding new keys on update)
 overlay_list: ""

--- a/optscale-deploy/overlay/user_template.yml
+++ b/optscale-deploy/overlay/user_template.yml
@@ -112,7 +112,26 @@ grafana:
 # Public ip of OptScale VM used in external integrations like emails,
 # google calendar etc. Defaults to internal ip, change it if internal ip
 # is not accessible in your network
+#
+# Public ip must be set to the fully qualified domain name of your OptScale instance
+# if you want to use cert-manager to manage the SSL certificate lifecycle.
+#
+# eg:
+#  public_ip: optscale.example.com
+#
 public_ip:
+
+ssl:
+  # set to false to not force ssl redirect on k8s ingress
+  force_redirect: true
+  # set to the name of your k8s secret which store the certificate
+  certificate_name: defaultcert
+  cert_manager:
+    # enable the cert-manager integration
+    enabled: false
+    # specify the name and the type of the issuer (issuer, cluster-issuer)
+    issuer:
+    issuer_type: issuer
 
 # Email verification is disabled by default. Set the flag to `False` to enable it
 disable_email_verification: True


### PR DESCRIPTION
## Description

This change allows the usage of [**cert-manager**](https://cert-manager.io) for the SSL certificate management.

## Related issue number

-
## Special notes

-

## Checklist

* [ ] The pull request title is a good summary of the changes
* [ ] Unit tests for the changes exist
* [ ] New and existing unit tests pass locally