### PR TITLE
MPT-11818 Diworker improvements

### DIFF
--- a/diworker/diworker/main.py
+++ b/diworker/diworker/main.py
@@ -56,7 +56,7 @@ class DIWorker(ConsumerMixin):
         self.thread.start()
         self.executor = ThreadPoolExecutor(
             max_workers=int(
-                config_cl.diworker_settings().get(
+                self.config_cl.diworker_settings().get(
                     'max_report_imports_workers',
                     DEFAULT_MAX_WORKERS
                 )
@@ -127,7 +127,7 @@ class DIWorker(ConsumerMixin):
             accept=['json'],
             callbacks=[self.process_task],
             prefetch_count=int(
-                config_cl.diworker_settings().get(
+                self.config_cl.diworker_settings().get(
                     'max_report_imports_workers',
                     DEFAULT_MAX_WORKERS
                 )

--- a/diworker/diworker/main.py
+++ b/diworker/diworker/main.py
@@ -3,7 +3,8 @@ import os
 import time
 
 import urllib3
-from threading import Thread
+from concurrent.futures import ThreadPoolExecutor
+from threading import Lock, Thread
 from etcd import Lock as EtcdLock
 from kombu import Exchange, Queue, Connection as QConnection
 from kombu.pools import producers
@@ -38,6 +39,7 @@ task_queue = Queue(
 LOG = get_logger(__name__)
 ENVIRONMENT_CLOUD_TYPE = 'environment'
 HEARTBEAT_INTERVAL = 300
+DEFAULT_MAX_WORKERS = 4
 
 
 class DIWorker(ConsumerMixin):
@@ -47,14 +49,29 @@ class DIWorker(ConsumerMixin):
         self._rest_cl = None
         self._mongo_cl = None
         self._clickhouse_cl = None
-        self.report_import_id = None
+        self.active_report_import_ids = set()
+        self.active_reports_lock = Lock()
+        self.running = True
         self.thread = Thread(target=self.heartbeat)
         self.thread.start()
+        self.executor = ThreadPoolExecutor(
+            max_workers=int(
+                config_cl.diworker_settings().get(
+                    'max_report_imports_workers',
+                    DEFAULT_MAX_WORKERS
+                )
+            )
+        )
 
     def heartbeat(self):
-        while True:
-            if self.report_import_id:
-                self.rest_cl.report_import_update(self.report_import_id, {})
+        while self.running:
+            with self.active_reports_lock:
+                report_import_ids = list(self.active_report_import_ids)
+            for report_import_id in report_import_ids:
+                try:
+                    self.rest_cl.report_import_update(report_import_id, {})
+                except Exception as e:
+                    LOG.warning("Heartbeat update failed for %s: %s", report_import_id, e)
             time.sleep(HEARTBEAT_INTERVAL)
 
     @property
@@ -109,29 +126,38 @@ class DIWorker(ConsumerMixin):
             queues=[task_queue],
             accept=['json'],
             callbacks=[self.process_task],
-            prefetch_count=1,
+            prefetch_count=int(
+                config_cl.diworker_settings().get(
+                    'max_report_imports_workers',
+                    DEFAULT_MAX_WORKERS
+                )
+            ),
         )]
 
     def report_import(self, task):
-        self.report_import_id = task.get('report_import_id')
-        if not self.report_import_id:
+        report_import_id = task.get('report_import_id')
+        if not report_import_id:
             raise Exception('invalid task received: {}'.format(task))
 
-        _, import_dict = self.rest_cl.report_import_get(self.report_import_id)
+        with self.active_reports_lock:
+            self.active_report_import_ids.add(report_import_id)
+
+        _, import_dict = self.rest_cl.report_import_get(report_import_id)
         cloud_acc_id = import_dict.get('cloud_account_id')
         _, resp = self.rest_cl.report_import_list(cloud_acc_id, show_active=True)
         imports = list(filter(
-            lambda x: x['id'] != self.report_import_id, resp['report_imports']))
+            lambda x: x['id'] != report_import_id, resp['report_imports']))
         if imports:
             reason = 'Import cancelled due another import: %s' % imports[0]['id']
             self.rest_cl.report_import_update(
-                self.report_import_id, {'state': 'failed',
-                                        'state_reason': reason})
+                report_import_id,
+                {'state': 'failed', 'state_reason': reason}
+            )
             return
         is_recalculation = import_dict.get('is_recalculation', False)
         LOG.info('Starting processing for task: %s, purpose %s',
                  task, 'recalculation ' if is_recalculation else 'import')
-        self.rest_cl.report_import_update(self.report_import_id,
+        self.rest_cl.report_import_update(report_import_id,
                                           {'state': 'in_progress'})
 
         importer_params = {
@@ -153,10 +179,11 @@ class DIWorker(ConsumerMixin):
             _, org = self.rest_cl.organization_get(organization_id)
             if org.get('disabled'):
                 reason = ('Import cancelled due to disabled '
-                          'organization: %s') % self.report_import_id
+                          'organization: %s') % report_import_id
                 self.rest_cl.report_import_update(
-                    self.report_import_id, {'state': 'failed',
-                                            'state_reason': reason})
+                    report_import_id,
+                    {'state': 'failed', 'state_reason': reason}
+                )
                 return
             start_last_import_ts = ca.get('last_import_at', 0)
             previous_attempt_ts = ca.get('last_import_attempt_at', 0)
@@ -166,7 +193,7 @@ class DIWorker(ConsumerMixin):
                 **importer_params)
             importer.import_report()
             self.rest_cl.report_import_update(
-                self.report_import_id, {'state': 'completed'})
+                report_import_id, {'state': 'completed'})
             if start_last_import_ts == 0 and cc_type != ENVIRONMENT_CLOUD_TYPE:
                 all_reports_finished = True
                 _, resp = self.rest_cl.cloud_account_list(organization_id)
@@ -186,7 +213,7 @@ class DIWorker(ConsumerMixin):
                 LOG.error('Mongo exception details: %s', exc.details)
             reason = str(exc)
             self.rest_cl.report_import_update(
-                self.report_import_id,
+                report_import_id,
                 {'state': 'failed', 'state_reason': reason}
             )
             now = int(time.time())
@@ -215,11 +242,16 @@ class DIWorker(ConsumerMixin):
             'organization.report_import.failed')
 
     def process_task(self, body, message):
+        self.executor.submit(self._process_task, body, message)
+
+    def _process_task(self, body, message):
         try:
             self.report_import(body)
         except Exception as exc:
             LOG.exception('Data import failed: %s', str(exc))
-        self.report_import_id = None
+        finally:
+            with self.active_reports_lock:
+                self.active_report_import_ids.discard(body.get('report_import_id'))
         message.ack()
 
 
@@ -245,4 +277,7 @@ if __name__ == '__main__':
             worker = DIWorker(conn, config_cl)
             worker.run()
         except KeyboardInterrupt:
-            print('bye bye')
+            worker.running = False
+            worker.executor.shutdown(wait=True)
+            worker.thread.join()
+            LOG.info("Shutdown worker")

--- a/diworker/requirements.txt
+++ b/diworker/requirements.txt
@@ -1,5 +1,5 @@
 pymongo==4.6.3
-kombu==5.3.4
+kombu==5.4.2
 boto3==1.34.7
 mongodb-migrations==0.7.0
 retrying==1.3.3

--- a/optscale-deploy/optscale/templates/tpl/_config.tpl
+++ b/optscale-deploy/optscale/templates/tpl/_config.tpl
@@ -82,6 +82,9 @@ etcd:
     port: {{ .Values.rest_api.service.externalPort }}
     demo:
       multiplier: {{ .Values.demo.multiplier }}
+    report_imports:
+      not_processed_threshold_secs: {{ .Values.import_reports.not_processed_threshold_secs }}
+      message_expiration_secs: {{ .Values.import_reports.message_expiration_secs }}
   auth:
     host: {{ .Values.auth.service.name }}
     port: {{ .Values.auth.service.externalPort }}
@@ -253,4 +256,6 @@ etcd:
     min_special_chars: {{ .Values.password_strength_settings.min_special_chars }}
   demo_org_cleanup:
     demo_org_lifetime_hrs: {{ .Values.demo_org_cleanup.demo_org_lifetime_hrs }}
+  diworker:
+    max_report_imports_workers: {{ .Value.import_reports.max_workers }}
 {{- end }}

--- a/optscale-deploy/optscale/templates/tpl/_config.tpl
+++ b/optscale-deploy/optscale/templates/tpl/_config.tpl
@@ -257,5 +257,5 @@ etcd:
   demo_org_cleanup:
     demo_org_lifetime_hrs: {{ .Values.demo_org_cleanup.demo_org_lifetime_hrs }}
   diworker:
-    max_report_imports_workers: {{ .Value.import_reports.max_workers }}
+    max_report_imports_workers: {{ .Values.import_reports.max_workers }}
 {{- end }}

--- a/optscale-deploy/optscale/values.yaml
+++ b/optscale-deploy/optscale/values.yaml
@@ -955,6 +955,11 @@ token_expiration: 168 # one week
 
 invite_expiration_days: 30 # days before invite url expiration
 
+import_reports:
+  message_expiration_secs: 10800 # 3 hours expiration to process a queue message
+  not_processed_threshold_secs: 10800 # 3 hours gap for report generating
+  max_workers: 10
+
 demo:
   multiplier: 2 # demo multiplier default value
 

--- a/optscale_client/config_client/client.py
+++ b/optscale_client/config_client/client.py
@@ -558,3 +558,15 @@ class Client(etcd.Client):
         Gets the Company name (Hystax)
         """
         return self.get("/company_name").value
+
+    def report_imports_setting(self):
+        """
+        Get settings for report imports
+        """
+        return self.read_branch('/restapi/report_imports')
+
+    def diworker_settings(self):
+        """
+        Get settings diworker
+        """
+        return self.read_branch('/diworker')

--- a/rest_api/rest_api_server/tests/unittests/test_schedule_imports.py
+++ b/rest_api/rest_api_server/tests/unittests/test_schedule_imports.py
@@ -3,6 +3,10 @@ from datetime import datetime, timedelta
 from unittest.mock import patch
 from freezegun import freeze_time
 
+from rest_api.rest_api_server.controllers.report_import import (
+    DEFAULT_QUEUE_MESSAGE_EXPIRATION_SECONDS,
+    DEFAULT_NOT_PROCESSED_REPORT_THRESHOLD_SECONDS,
+)
 from rest_api.rest_api_server.models.db_factory import DBFactory, DBType
 from rest_api.rest_api_server.models.db_base import BaseDB
 from rest_api.rest_api_server.models.models import CloudAccount
@@ -26,6 +30,13 @@ class TestScheduleImportsApi(TestApiBase):
         self.org_id2 = self.org2['id']
         patch('rest_api.rest_api_server.controllers.report_import.'
               'ReportImportBaseController.publish_task').start()
+        patch(
+            'optscale_client.config_client.client.Client.report_imports_setting',
+            return_value={
+                'not_processed_threshold_secs': DEFAULT_NOT_PROCESSED_REPORT_THRESHOLD_SECONDS,
+                'message_expiration_secs': DEFAULT_QUEUE_MESSAGE_EXPIRATION_SECONDS,
+            }
+        ).start()
 
     def test_schedule_imports_without_cloud_acc(self):
         code, ret = self.client.schedule_import(0)


### PR DESCRIPTION
## Description

This pull request includes two improves of report imports:
- ability to execute multiple imports in a thread reducing overall processing time with configurable worker capacity
- configurable threshold for not processed reports, allows a more flexible approach to control reports

Fixes:
- added a configurable message expiration for import report queue, this will help to avoid overpopulating queue in case of any system failures
- fixed a not closed heartbeat thread for DIWorker

Proposals:
- bump kombu as [reconnection bug was fixed](https://docs.celeryq.dev/projects/kombu/en/stable/changelog.html#version-5-4-0), version 5.4.0 was released one year ago, but somehow is still not tagged as stable, so probably this bump isn't appropriate 

## Related issue number

<!-- Please link a pull request to an issue by using "fixes #10" style references to close the issue when this PR is merged. -->

## Special notes

Agree on if kombu bump is okay

## Checklist

* [ ] The pull request title is a good summary of the changes
* [ ] Unit tests for the changes exist
* [ ] New and existing unit tests pass locally