### PR TITLE
Correct case-sensitive check for ERROR_CHANNEL status

### DIFF
--- a/optscale-deploy/runkube.py
+++ b/optscale-deploy/runkube.py
@@ -327,7 +327,7 @@ class Runkube:
                                 tty=False, _preload_content=False)
             client.run_forever(timeout=60)
             err = client.read_channel(ERROR_CHANNEL)
-            if yaml.safe_load(err)['status'].lower() == 'Failure':
+            if yaml.safe_load(err)['status'].lower() == 'failure':
                 return []
             overlay_str = client.read_all().rstrip()
             overlay_list = [] if not overlay_str else overlay_str.split(',')


### PR DESCRIPTION
## Description
This small PR fixes the case-sensitive check for the ERROR_CHANNEL status. Previously, the comparison was case-insensitive, which could incorrectly match other statuses with similar names but different casing. The updated logic enforces an exact case-sensitive match, ensuring only the correct ERROR_CHANNEL status is detected.

## Related issue number

## Special notes

## Checklist

* [x] The pull request title is a good summary of the changes
* [ ] Unit tests for the changes exist
* [ ] New and existing unit tests pass locally