### PR TITLE
perf: improve insider worker memory usage when using multiple currencies

### DIFF
--- a/insider/insider_api/uv.lock
+++ b/insider/insider_api/uv.lock
@@ -553,7 +553,7 @@ requires-dist = [
     { name = "msrest", specifier = "==0.7.1" },
     { name = "oauthlib", specifier = "==3.2.2" },
     { name = "requests", specifier = "==2.32.4" },
-    { name = "retrying", specifier = "==1.3.3" },
+    { name = "retrying", specifier = ">=1.4.1" },
     { name = "urllib3", specifier = "==2.5.0" },
     { name = "yandexcloud", specifier = ">=0.327.0" },
 ]
@@ -1001,7 +1001,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "requests", specifier = "==2.32.4" },
-    { name = "retrying", specifier = "==1.3.3" },
+    { name = "retrying", specifier = ">=1.4.1" },
 ]
 
 [[package]]
@@ -1371,17 +1371,17 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "requests", specifier = "==2.32.4" },
-    { name = "retrying", specifier = "==1.3.3" },
+    { name = "retrying", specifier = ">=1.4.1" },
 ]
 
 [[package]]
 name = "retrying"
-version = "1.3.3"
+version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
+sdist = { url = "https://files.pythonhosted.org/packages/c8/5a/b17e1e257d3e6f2e7758930e1256832c9ddd576f8631781e6a072914befa/retrying-1.4.2.tar.gz", hash = "sha256:d102e75d53d8d30b88562d45361d6c6c934da06fab31bd81c0420acb97a8ba39", size = 11411, upload-time = "2025-08-03T03:35:25.189Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/f3/6cd296376653270ac1b423bb30bd70942d9916b6978c6f40472d6ac038e7/retrying-1.4.2-py3-none-any.whl", hash = "sha256:bbc004aeb542a74f3569aeddf42a2516efefcdaff90df0eb38fbfbf19f179f59", size = 10859, upload-time = "2025-08-03T03:35:23.829Z" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/44/ef/beae4b4ef80902f22e3af073397f079c96969c69b2c7d52a57ea9ae61c9d/retrying-1.3.3.tar.gz", hash = "sha256:08c039560a6da2fe4f2c426d0766e284d3b736e355f8dd24b37367b0bb41973b", size = 10890, upload-time = "2014-12-15T01:15:08.281Z" }
 
 [[package]]
 name = "rsa"

--- a/insider/insider_scheduler/uv.lock
+++ b/insider/insider_scheduler/uv.lock
@@ -149,7 +149,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "requests", specifier = "==2.32.4" },
-    { name = "retrying", specifier = "==1.3.3" },
+    { name = "retrying", specifier = ">=1.4.1" },
 ]
 
 [[package]]
@@ -358,12 +358,12 @@ wheels = [
 
 [[package]]
 name = "retrying"
-version = "1.3.3"
+version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
+sdist = { url = "https://files.pythonhosted.org/packages/c8/5a/b17e1e257d3e6f2e7758930e1256832c9ddd576f8631781e6a072914befa/retrying-1.4.2.tar.gz", hash = "sha256:d102e75d53d8d30b88562d45361d6c6c934da06fab31bd81c0420acb97a8ba39", size = 11411, upload-time = "2025-08-03T03:35:25.189Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/f3/6cd296376653270ac1b423bb30bd70942d9916b6978c6f40472d6ac038e7/retrying-1.4.2-py3-none-any.whl", hash = "sha256:bbc004aeb542a74f3569aeddf42a2516efefcdaff90df0eb38fbfbf19f179f59", size = 10859, upload-time = "2025-08-03T03:35:23.829Z" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/44/ef/beae4b4ef80902f22e3af073397f079c96969c69b2c7d52a57ea9ae61c9d/retrying-1.3.3.tar.gz", hash = "sha256:08c039560a6da2fe4f2c426d0766e284d3b736e355f8dd24b37367b0bb41973b", size = 10890 }
 
 [[package]]
 name = "sentinels"

--- a/insider/insider_worker/processors/azure.py
+++ b/insider/insider_worker/processors/azure.py
@@ -81,17 +81,19 @@ class AzurePriceProcessor(BasePriceProcessor):
 
     def process_prices(self):
         last_discovery = self.get_last_discovery()
-        old_prices = self.prices.find(
-            {'last_seen': {'$gte': last_discovery.get('started_at', 0)}},
-            {k: 1 for k in self.UNIQUE_FIELDS + self.CHANGE_FIELDS + ['last_seen']}
-        )
-        old_prices_map = {self.unique_values(p): p for p in old_prices}
 
         http_client = Client()
-        processed_keys = {}
-        prices_counter = 0
         for currency in self._get_currencies_list():
             LOG.info('Processing Azure prices for currency: %s', currency)
+
+            old_prices = self.prices.find(
+                {'last_seen': {'$gte': last_discovery.get('started_at', 0)}, 'currencyCode': currency},
+                {k: 1 for k in self.UNIQUE_FIELDS + self.CHANGE_FIELDS + ['last_seen']}
+            )
+            old_prices_map = {self.unique_values(p): p for p in old_prices}
+            processed_keys = {}
+            prices_counter = 0
+            
             next_page = 'https://prices.azure.com/api/retail/prices'
             next_page += '?currencyCode=%s' % currency
             while True:

--- a/insider/insider_worker/processors/azure.py
+++ b/insider/insider_worker/processors/azure.py
@@ -1,13 +1,13 @@
 from datetime import datetime, timezone
-from kombu.log import get_logger
-from requests.exceptions import SSLError
+
+from insider.insider_worker.http_client.client import Client
+from insider.insider_worker.processors.base import BasePriceProcessor
 from kombu import Connection as QConnection
 from kombu import Exchange
+from kombu.log import get_logger
 from kombu.pools import producers
 from optscale_client.rest_api_client.client_v2 import Client as RestClient
-from insider.insider_worker.processors.base import BasePriceProcessor
-from insider.insider_worker.http_client.client import Client
-
+from requests.exceptions import SSLError
 
 ACTIVITIES_EXCHANGE_NAME = 'activities-tasks'
 ACTIVITIES_EXCHANGE = Exchange(ACTIVITIES_EXCHANGE_NAME, type='topic')
@@ -91,6 +91,7 @@ class AzurePriceProcessor(BasePriceProcessor):
         processed_keys = {}
         prices_counter = 0
         for currency in self._get_currencies_list():
+            LOG.info('Processing Azure prices for currency: %s', currency)
             next_page = 'https://prices.azure.com/api/retail/prices'
             next_page += '?currencyCode=%s' % currency
             while True:

--- a/insider/insider_worker/processors/azure.py
+++ b/insider/insider_worker/processors/azure.py
@@ -92,7 +92,7 @@ class AzurePriceProcessor(BasePriceProcessor):
             old_prices_map = {self.unique_values(p): p for p in old_prices}
             processed_keys = {}
             prices_counter = 0
-            
+
             next_page = 'https://prices.azure.com/api/retail/prices'
             next_page += '?currencyCode=%s' % currency
             while True:

--- a/insider/insider_worker/processors/azure.py
+++ b/insider/insider_worker/processors/azure.py
@@ -12,7 +12,6 @@ from requests.exceptions import SSLError
 ACTIVITIES_EXCHANGE_NAME = 'activities-tasks'
 ACTIVITIES_EXCHANGE = Exchange(ACTIVITIES_EXCHANGE_NAME, type='topic')
 LOG = get_logger(__name__)
-PRICES_PER_REQUEST = 100
 PRICES_COUNT_TO_LOG = 1000
 
 
@@ -119,7 +118,7 @@ class AzurePriceProcessor(BasePriceProcessor):
                              'cloud: %s', prices_counter)
                     break
                 next_page = new_url
-                prices_counter += PRICES_PER_REQUEST
+                prices_counter += response.get('Count', 0)
 
     def update_price_records(self, new_prices_map, old_prices_map,
                              processed_keys):

--- a/insider/insider_worker/pyproject.toml
+++ b/insider/insider_worker/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "pymongo==4.6.3",
     "requests==2.32.4",
     "restapi-client",
+    "retrying>=1.4",
 ]
 
 [tool.uv.sources]

--- a/insider/insider_worker/uv.lock
+++ b/insider/insider_worker/uv.lock
@@ -149,7 +149,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "requests", specifier = "==2.32.4" },
-    { name = "retrying", specifier = "==1.3.3" },
+    { name = "retrying", specifier = ">=1.4.1" },
 ]
 
 [[package]]
@@ -162,6 +162,7 @@ dependencies = [
     { name = "pymongo" },
     { name = "requests" },
     { name = "restapi-client" },
+    { name = "retrying" },
 ]
 
 [package.dev-dependencies]
@@ -182,6 +183,7 @@ requires-dist = [
     { name = "pymongo", specifier = "==4.6.3" },
     { name = "requests", specifier = "==2.32.4" },
     { name = "restapi-client", directory = "../../optscale_client/rest_api_client" },
+    { name = "retrying", specifier = ">=1.4" },
 ]
 
 [package.metadata.requires-dev]
@@ -376,17 +378,17 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "requests", specifier = "==2.32.4" },
-    { name = "retrying", specifier = "==1.3.3" },
+    { name = "retrying", specifier = ">=1.4.1" },
 ]
 
 [[package]]
 name = "retrying"
-version = "1.3.3"
+version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
+sdist = { url = "https://files.pythonhosted.org/packages/c8/5a/b17e1e257d3e6f2e7758930e1256832c9ddd576f8631781e6a072914befa/retrying-1.4.2.tar.gz", hash = "sha256:d102e75d53d8d30b88562d45361d6c6c934da06fab31bd81c0420acb97a8ba39", size = 11411, upload-time = "2025-08-03T03:35:25.189Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/f3/6cd296376653270ac1b423bb30bd70942d9916b6978c6f40472d6ac038e7/retrying-1.4.2-py3-none-any.whl", hash = "sha256:bbc004aeb542a74f3569aeddf42a2516efefcdaff90df0eb38fbfbf19f179f59", size = 10859, upload-time = "2025-08-03T03:35:23.829Z" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/44/ef/beae4b4ef80902f22e3af073397f079c96969c69b2c7d52a57ea9ae61c9d/retrying-1.3.3.tar.gz", hash = "sha256:08c039560a6da2fe4f2c426d0766e284d3b736e355f8dd24b37367b0bb41973b", size = 10890 }
 
 [[package]]
 name = "sentinels"

--- a/optscale_client/insider_client/setup.py
+++ b/optscale_client/insider_client/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup
 
 
-requirements = ["requests==2.32.4", "retrying==1.3.3"]
+requirements = ["requests==2.32.4", "retrying>=1.4.1"]
 
 setup(name='insider-client',
       description='Hystax Insider Client',

--- a/optscale_client/rest_api_client/setup.py
+++ b/optscale_client/rest_api_client/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup
 
 
-requirements = ["requests==2.32.4", "retrying==1.3.3"]
+requirements = ["requests==2.32.4", "retrying>=1.4.1"]
 
 setup(name='restapi-client',
       description='OptScale REST API Client',

--- a/tools/cloud_adapter/setup.py
+++ b/tools/cloud_adapter/setup.py
@@ -49,7 +49,7 @@ requirements = [
     'databricks-sdk==0.11.0',
 
     "requests==2.32.4",
-    "retrying==1.3.3",
+    "retrying>=1.4.1",
 ]
 
 setup(name='cloud-adapter',


### PR DESCRIPTION
## Description

We've been experiencing issues with the memory usage of the insider worker (>10 GB of RAM used per run). After setting up profiling and looking at the reports on different setups we found that there are a few issues happening at the same time which contributed to the high usage:

1. We have organisations with 17 unique currencies, running the insider worker with just a couple of currencies consumes drastically less memory
2. The insider worker loads the existing currencies in memory since the last processing period. That's a lot of data and it scaled linearly with the amount of currencies used. We initially tried to fix this issue by loading only the necessary prices page by page (as there are still ~700 pages of prices per currency returned by the Azure API) and while this fixed the issue, the processing of pages became significantly slower (to the point where we cannot process all currencies within 24 hours).
3. Even when processing a couple of currencies the flamegraph indicated that 2.1 GB of memory was consumed by objects coming from the `retrying` library. This problem was hard to notice as it was happening slowly in the background over the timespan of 24 hours. Updating this library seemed to have helped with that

In addition to updating the library we also moved the fetching of previous prices to be per currency which seems to be enough to lower the memory consumption to <2GB and keep it consistent

## Related issue number

<!-- Please link a pull request to an issue by using "fixes #10" style references to close the issue when this PR is merged. -->

## Special notes

<!-- Please provide additional information if required. -->

## Checklist

* [ ] The pull request title is a good summary of the changes
* [ ] Unit tests for the changes exist
* [ ] New and existing unit tests pass locally