### PR TITLE
fix: Update nginx ingress controller values file path

### DIFF
--- a/optscale-deploy/ansible/roles/k8s-configure/tasks/main.yaml
+++ b/optscale-deploy/ansible/roles/k8s-configure/tasks/main.yaml
@@ -71,7 +71,7 @@
   run_once: true
 
 - name: Install nginx ingress controller
-  shell: helm upgrade --install ngingress ingress-nginx --repo https://kubernetes.github.io/ingress-nginx -f nginx-ingress/values.yaml
+  shell: helm upgrade --install ngingress ingress-nginx --repo https://kubernetes.github.io/ingress-nginx -f roles/k8s-configure/files/nginx-ingress/values.yaml
   run_once: true
 
 - name: Check domain presence


### PR DESCRIPTION
## Description

This pull request fixes a deployment failure in the `k8s-configure` role caused by an incorrect file path for the `nginx-ingress` controller's Helm values.

* The Helm install command was referencing `nginx-ingress/values.yaml`, which was the wrong relative path.
* This caused the Ansible playbook to fail with a `non-zero return code` and the error: `Error: open nginx-ingress/values.yaml: no such file or directory`.
* This PR updates the Helm command to use the correct path: `roles/k8s-configure/files/nginx-ingress/values.yaml`.

This resolves the following fatal error:
`fatal: [10.10.0.2]: FAILED! => {"changed": true, "cmd": "helm upgrade --install ngingress ingress-nginx --repo [suspicious link removed] -f nginx-ingress/values.yaml", "delta": "0:00:08.183672", "end": "2025-10-27 09:16:05.457648", "msg": "non-zero return code", "rc": 1, "start": "2025-10-27 09:15:57.273976", "stderr": "Error: open nginx-ingress/values.yaml: no such file or directory", "stderr_lines": ["Error: open nginx-ingress/values.yaml: no such file or directory"], "stdout": "Release "ngingress" does not exist. Installing it now.", "stdout_lines": ["Release "ngingress" does not exist. Installing it now."]}`

## Related issue number

Fixes #749 

## Special notes

This issue occurred in this [commit](https://github.com/hystax/optscale/commit/6bd641743efd0846f0ef808b05063dfc6d6d0114).

## Checklist

* [x] The pull request title is a good summary of the changes
* [x] Tested out with the forked repository
