### PR TITLE
AWS cloud adapter - Use regional STS endpoint for opt-in regions

### DIFF
--- a/tools/cloud_adapter/clouds/aws.py
+++ b/tools/cloud_adapter/clouds/aws.py
@@ -145,7 +145,13 @@ class Aws(S3CloudMixin):
                 region_name=region_name,
             )
 
-            sts_client = base_session.client('sts', config=IAM_CLIENT_CONFIG)
+            # Use regional STS endpoint for opt-in regions
+            sts_endpoint_url = f'https://sts.{region_name}.amazonaws.com'
+            sts_client = base_session.client(
+                'sts',
+                endpoint_url=sts_endpoint_url,
+                config=IAM_CLIENT_CONFIG
+            )
             response = sts_client.assume_role(
                 RoleArn=f'arn:aws:iam::{role_account_id}:role/{role_name}',
                 RoleSessionName=role_session_name,


### PR DESCRIPTION
Fixing errors when pulling metrics for opt-in regions(for example Zurich)

## Description

The STS client will use the regional endpoint explicitly. This should work for opt-in
  regions. The change ensures that when assuming a role, it uses the regional STS endpoint (e.g.,
  https://sts.eu-central-2.amazonaws.com) instead of the global one, which is required for these newer
   regions to work properly.

