### PR TITLE
OSN-1287: update auto-assign workflow configuration

### DIFF
--- a/.github/workflows/auto-assign-author.yml
+++ b/.github/workflows/auto-assign-author.yml
@@ -9,16 +9,50 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      issues: write  # Required because assignees API works via issues 
+      contents: read # Minimal read access to repository contents
 
     steps:
       - name: Assign PR author
         uses: actions/github-script@v8
         with:
           script: |
-            const reporter = context.actor
-            await github.rest.issues.addAssignees({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              assignees: [reporter]
-            })
+            // Repository owner (organization or user who owns the repo)
+            const owner = context.repo.owner;
+
+            // Repository name
+            const repo = context.repo.repo;
+
+            // Login of the pull request author
+            const prAuthor = context.payload.pull_request.user.login;
+
+            try {
+              // Check the permission level of the PR author
+              const { data: perm } =
+                await github.rest.repos.getCollaboratorPermissionLevel({
+                  owner,
+                  repo,
+                  username: prAuthor
+                });
+
+              // If the author has write/maintain/admin rights → assign them to the PR
+              if (["write", "maintain", "admin"].includes(perm.permission)) {
+                await github.rest.issues.addAssignees({
+                  owner,
+                  repo,
+                  issue_number: context.payload.pull_request.number,
+                  assignees: [prAuthor]
+                });
+                console.log(`Assigned PR to ${prAuthor}`);
+              } else {
+                // If the author has insufficient rights → skip assignment
+                console.log(
+                  `Skipping assignment for ${prAuthor}: permission=${perm.permission}`
+                );
+              }
+            } catch (error) {
+              // If the author is not a collaborator (e.g., PR from a fork) → skip without failing
+              console.log(
+                `Skipping assignment for ${prAuthor}: not a collaborator`
+              );
+            }


### PR DESCRIPTION
What was changed:
The workflow .github/workflows/auto-assign-author.yml was modified to automatically assign the pull request author as an assignee when a PR is opened or reopened.
The logic now includes a permission check via GitHub API (getCollaboratorPermissionLevel) and safe handling of cases where the author is not a collaborator (e.g., PRs coming from forks).

If the author has write, maintain, or admin rights — they are assigned.
If the author has insufficient rights or is external — the step is skipped without error, with a clear log message.

To verify workflow stability with external PRs, the following test was conducted:

1. From the external account DaniyaAbdulina, a fork of the repository hystax/optscale was created → DaniyaAbdulina/optscale.
2. The fork was cloned to a separate VM.
3. A new branch test was created, changes were made, and pushed to DaniyaAbdulina/optscale.
4. A pull request was opened from DaniyaAbdulina:test into hystax:usr/kirill_mas/OSN-1287.

Result: The workflow successfully executed on PR test_commit #23, correctly skipping assignment for the external author with the log:
Skipping assignment for DaniyaAbdulina: permission=read
