### PR TITLE
Improve review-loop ergonomics: AGENTS.md + SDK ctor lock + cache isolation tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# Agent guidelines for OptScale
+
+This file gives review agents (Codex, Claude Code, etc.) context about the codebase so they don't re-flag intentional patterns or miss class-level conventions.
+
+## Review guidelines
+
+### Module identity (`unique_record_keys`)
+
+Recommendation modules under `bumiworker/bumiworker/modules/recommendations/` that can emit multiple rows per cloud resource MUST override the base class `unique_record_keys` property to include the discriminating field (e.g., tier pair, severity, time window). The override appears as a class-level `@property` returning a tuple — typical examples:
+
+- `azure_cold_tier_candidates.py` line 49: returns `('cloud_account_id', 'cloud_resource_id', 'current_tier', 'target_tier')` — discriminates Hot→Cold vs Cool→Cold rows for the same storage account.
+- The matching archive module under `bumiworker/bumiworker/modules/archive/` exposes the SAME tuple at its corresponding line.
+
+When you see the row-emission loop and your first instinct is to flag "missing `unique_record_keys`", scan the class header (typically lines 40-60) for an `@property` with name `unique_record_keys` BEFORE flagging. Do not re-flag if the override is present and includes the discriminating fields the loop emits.
+
+### Helper scope filtering
+
+The `bumiworker/bumiworker/modules/azure_helpers/reservations.py` helper accepts both legacy `applied_scopes` and newer `applied_scope_properties.subscription_id` payload shapes (lines ~204-215 in current head). Single-scope reservations narrower than the subscription (e.g., resource-group scoped) are conservatively skipped because the helper has no resource-RG context. This is intentional — under-discount is safer than phantom over-savings.
+
+### Archive module phantom fields
+
+When an archive module reads a `meta.<field>` for state classification (e.g., RECOMMENDATION_APPLIED detection), the field MUST have a writer somewhere in `tools/cloud_adapter/clouds/*.py` or `rest_api/restapi/handlers/*` for the relevant cloud. If no writer exists, the module currently uses a conservative IRRELEVANT fallthrough plus a TODO. Do not flag the IRRELEVANT branch as "should be APPLIED" — the gap is documented and intentional pending discovery-layer changes.
+
+## Conventions
+
+- New recommendation modules: cloud-agnostic registration (no AWS/Hystax-specific shortcuts).
+- Sibling-resource lookups: filter `employee_id != null AND pool_id != null`, sort `[("created_at", 1), ("_id", 1)]`. Null leaks crash the frontend Filters component organisation-wide.
+- Azure SDK matrix: track-1 (storage/compute/monitor) uses `msrestazure.ServicePrincipalCredentials`; track-2 (network/identity) uses `azure.identity.ClientSecretCredential`. Don't cross.
+- Recommendation tile: bumiworker module filename MUST equal `type` field on the ngui tile class.
+- Recommendation tile dual-registration: BOTH `allRecommendations.ts` AND `useOptscaleRecommendations.ts`.
+- Recommendation tile title: plain text only — `Cards.tsx` renders without a `values` prop.

--- a/bumiworker/bumiworker/modules/azure_helpers/tests/test_reservations.py
+++ b/bumiworker/bumiworker/modules/azure_helpers/tests/test_reservations.py
@@ -1,0 +1,364 @@
+"""Unit tests for the reservation rate helper, focused on the two
+correctness fixes flagged by Codex on PR #1:
+
+  1. Cache must be keyed by subscription_id (cross-sub poisoning).
+  2. applied_scope must be honoured (Single-scope reservation must not
+     discount sibling subscriptions; ManagementGroup-scope conservatively
+     skipped).
+"""
+import sys
+import types
+from unittest import mock
+
+import pytest
+
+from bumiworker.bumiworker.modules.azure_helpers import reservations
+from bumiworker.bumiworker.modules.azure_helpers.reservations import (
+    get_effective_storage_rate,
+)
+
+
+# ---- helpers ----------------------------------------------------------
+
+class _Sku:
+    def __init__(self, name):
+        self.name = name
+
+
+class _AppliedScopeProps:
+    def __init__(self, subscription_id=None):
+        self.subscription_id = subscription_id
+
+
+class _Props:
+    def __init__(self, term="1 Year", applied_scope_type=None,
+                 applied_scopes=None, applied_scope_properties=None):
+        self.term = term
+        self.applied_scope_type = applied_scope_type
+        self.applied_scopes = applied_scopes or []
+        self.applied_scope_properties = applied_scope_properties
+
+
+class _Reservation:
+    def __init__(self, sku_name, applied_scope_type=None,
+                 applied_scopes=None, term="1 Year",
+                 applied_scope_properties=None):
+        self.sku = _Sku(sku_name)
+        self.properties = _Props(
+            term=term,
+            applied_scope_type=applied_scope_type,
+            applied_scopes=applied_scopes,
+            applied_scope_properties=applied_scope_properties,
+        )
+
+
+def _install_fake_azure_sdk():
+    """Inject lightweight stubs for azure.mgmt.reservations and
+    azure.core.exceptions so the helper's lazy imports succeed without
+    real Azure deps. Returns the AzureReservationAPI mock the test can
+    program."""
+    api_mock = mock.MagicMock(name="AzureReservationAPI")
+
+    mgmt_mod = types.ModuleType("azure.mgmt.reservations")
+    mgmt_mod.AzureReservationAPI = api_mock
+
+    # azure.core.exceptions.HttpResponseError — provide a real class so
+    # `raise` works in tests that need it.
+    core_exc_mod = types.ModuleType("azure.core.exceptions")
+
+    class HttpResponseError(Exception):
+        pass
+
+    core_exc_mod.HttpResponseError = HttpResponseError
+
+    # Parent packages must exist for `from azure.mgmt.reservations ...`
+    # style imports to resolve.
+    azure_pkg = sys.modules.get("azure") or types.ModuleType("azure")
+    azure_mgmt_pkg = sys.modules.get("azure.mgmt") or types.ModuleType("azure.mgmt")
+    azure_core_pkg = sys.modules.get("azure.core") or types.ModuleType("azure.core")
+
+    sys.modules["azure"] = azure_pkg
+    sys.modules["azure.mgmt"] = azure_mgmt_pkg
+    sys.modules["azure.mgmt.reservations"] = mgmt_mod
+    sys.modules["azure.core"] = azure_core_pkg
+    sys.modules["azure.core.exceptions"] = core_exc_mod
+
+    return api_mock, HttpResponseError
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    reservations._CACHE.clear()
+    yield
+    reservations._CACHE.clear()
+
+
+@pytest.fixture
+def api_mock():
+    api, _exc = _install_fake_azure_sdk()
+    api.reset_mock()
+    return api
+
+
+@pytest.fixture
+def http_error():
+    _api, exc = _install_fake_azure_sdk()
+    return exc
+
+
+# ---- BUG 1: cache isolation by subscription_id ------------------------
+
+def test_reservation_api_ctor_signature(api_mock):
+    """AzureReservationAPI is a tenant-wide service: ctor takes
+    (credentials, base_url=None, **kwargs). subscription_id MUST NOT be
+    passed positionally — doing so makes it base_url and list_all hits
+    an invalid endpoint (silently 0 reservations -> phantom over-savings).
+    """
+    api_mock.return_value.reservation.list_all.return_value = iter([])
+    creds = mock.Mock(name="credential")
+    get_effective_storage_rate(
+        credential=creds, subscription_id="any-sub",
+        region="eastus", redundancy="LRS", tier="Hot")
+    args, kwargs = api_mock.call_args
+    assert args == (creds,), (
+        f"AzureReservationAPI ctor must receive only credentials positionally; "
+        f"got args={args} kwargs={kwargs}. subscription_id leaking into base_url "
+        f"breaks reservation.list_all()."
+    )
+    assert "subscription_id" not in kwargs
+
+
+def test_cache_isolated_by_subscription_id(api_mock):
+    """A second call with a different subscription_id must NOT reuse the
+    first call's cached entry — list_all must be invoked again."""
+    # Return an empty list both times — what we care about is whether the
+    # SDK was hit twice.
+    api_mock.return_value.reservation.list_all.return_value = iter([])
+    # subA
+    rate_a = get_effective_storage_rate(
+        credential=mock.Mock(), subscription_id="subA",
+        region="eastus", redundancy="LRS", tier="Hot")
+    # subB — same region/redundancy/tier
+    api_mock.return_value.reservation.list_all.return_value = iter([])
+    rate_b = get_effective_storage_rate(
+        credential=mock.Mock(), subscription_id="subB",
+        region="eastus", redundancy="LRS", tier="Hot")
+
+    assert rate_a is None
+    assert rate_b is None
+    assert api_mock.return_value.reservation.list_all.call_count == 2, (
+        "expected list_all to be called once per subscription; the cache "
+        "key is leaking across subs"
+    )
+
+
+def test_cache_isolated_by_subscription_id_distinct_values(api_mock):
+    """Cached rate for subA must not bleed into subB when they share
+    region/redundancy/tier but hold different reservation sets.
+
+    subA  — Single-scope reservation targeting /subscriptions/subA → rate 0.02
+    subB  — no reservations → rate None
+
+    The test exercises three guarantees:
+      1. subA resolves to the reservation rate, not None.
+      2. subB resolves to None despite the prior subA cache entry.
+      3. A second subA call returns 0.02 from cache without hitting the SDK
+         again (list_all call_count does not increase after the subB call).
+    """
+    res_a = _Reservation(
+        sku_name="Blob_Storage_Reserved_Capacity_LRS_Hot_100TB",
+        applied_scope_type="Single",
+        applied_scopes=["/subscriptions/subA"],
+    )
+    api_mock.return_value.reservation.list_all.side_effect = [
+        iter([res_a]),  # subA first call
+        iter([]),       # subB first call — subA second call must hit cache
+    ]
+
+    with mock.patch.object(reservations,
+                           "_fetch_retail_reservation_rate",
+                           return_value=0.02):
+        rate_a_first = get_effective_storage_rate(
+            credential=mock.Mock(), subscription_id="subA",
+            region="eastus", redundancy="LRS", tier="Hot")
+
+        count_after_sub_a = (
+            api_mock.return_value.reservation.list_all.call_count)
+
+        rate_b = get_effective_storage_rate(
+            credential=mock.Mock(), subscription_id="subB",
+            region="eastus", redundancy="LRS", tier="Hot")
+
+        rate_a_second = get_effective_storage_rate(
+            credential=mock.Mock(), subscription_id="subA",
+            region="eastus", redundancy="LRS", tier="Hot")
+
+    assert rate_a_first == 0.02, (
+        "subA reservation should resolve to the retail rate 0.02; "
+        "Single-scope match with /subscriptions/subA failed"
+    )
+    assert rate_b is None, (
+        "subB has no reservations; subA's cached entry must not bleed into "
+        "subB's lookup — cache key must include subscription_id"
+    )
+    assert rate_a_second == 0.02, (
+        "subA second call must return 0.02 from cache; "
+        "the cached value must survive an interleaved subB lookup"
+    )
+    assert api_mock.return_value.reservation.list_all.call_count == (
+        count_after_sub_a + 1), (
+        "list_all should have been called exactly once for subA (first call) "
+        "and once for subB; subA second call must be served from cache"
+    )
+
+
+# ---- BUG 2: applied_scope filter --------------------------------------
+
+def test_single_scope_other_subscription_skipped(api_mock):
+    res = _Reservation(
+        sku_name="Blob_Storage_Reserved_Capacity_LRS_Hot_100TB",
+        applied_scope_type="Single",
+        applied_scopes=["/subscriptions/subA"],
+    )
+    api_mock.return_value.reservation.list_all.return_value = iter([res])
+
+    # Even if retail pricing would otherwise resolve a rate, the loop
+    # must `continue` past this reservation before reaching the SKU
+    # match — so patching _fetch_retail_reservation_rate to a non-None
+    # sentinel still yields None.
+    with mock.patch.object(reservations,
+                           "_fetch_retail_reservation_rate",
+                           return_value=0.99):
+        rate = get_effective_storage_rate(
+            credential=mock.Mock(), subscription_id="subB",
+            region="eastus", redundancy="LRS", tier="Hot")
+    assert rate is None
+
+
+def test_single_scope_resource_group_scoped_skipped(api_mock):
+    """A reservation single-scoped to a specific resource group should
+    NOT discount sibling RGs in the same subscription. The helper has
+    no resource RG context, so RG-scoped reservations are conservatively
+    skipped (under-discount is safer than phantom)."""
+    res = _Reservation(
+        sku_name="Blob_Storage_Reserved_Capacity_LRS_Hot_100TB",
+        applied_scope_type="Single",
+        applied_scopes=["/subscriptions/subA/resourceGroups/rg1"],
+    )
+    api_mock.return_value.reservation.list_all.return_value = iter([res])
+    with mock.patch.object(reservations,
+                           "_fetch_retail_reservation_rate",
+                           return_value=0.05):
+        rate = get_effective_storage_rate(
+            credential=mock.Mock(), subscription_id="subA",
+            region="eastus", redundancy="LRS", tier="Hot")
+    assert rate is None, (
+        "RG-scoped reservation must not discount the helper's "
+        "subscription-level rate query")
+
+
+def test_single_scope_via_applied_scope_properties(api_mock):
+    """Newer reservation payloads can carry the target subscription on
+    properties.applied_scope_properties.subscription_id with applied_scopes
+    empty/deprecated. Helper must accept either source."""
+    res = _Reservation(
+        sku_name="Blob_Storage_Reserved_Capacity_LRS_Hot_100TB",
+        applied_scope_type="Single",
+        applied_scopes=[],
+        applied_scope_properties=_AppliedScopeProps(
+            subscription_id="/subscriptions/subA"),
+    )
+    api_mock.return_value.reservation.list_all.return_value = iter([res])
+    with mock.patch.object(reservations,
+                           "_fetch_retail_reservation_rate",
+                           return_value=0.04):
+        rate = get_effective_storage_rate(
+            credential=mock.Mock(), subscription_id="subA",
+            region="eastus", redundancy="LRS", tier="Hot")
+    assert rate == 0.04
+
+
+def test_single_scope_via_applied_scope_properties_other_sub_skipped(api_mock):
+    res = _Reservation(
+        sku_name="Blob_Storage_Reserved_Capacity_LRS_Hot_100TB",
+        applied_scope_type="Single",
+        applied_scopes=[],
+        applied_scope_properties=_AppliedScopeProps(
+            subscription_id="/subscriptions/subA"),
+    )
+    api_mock.return_value.reservation.list_all.return_value = iter([res])
+    with mock.patch.object(reservations,
+                           "_fetch_retail_reservation_rate",
+                           return_value=0.04):
+        rate = get_effective_storage_rate(
+            credential=mock.Mock(), subscription_id="subB",
+            region="eastus", redundancy="LRS", tier="Hot")
+    assert rate is None
+
+
+def test_single_scope_matching_subscription_accepted(api_mock):
+    res = _Reservation(
+        sku_name="Blob_Storage_Reserved_Capacity_LRS_Hot_100TB",
+        applied_scope_type="Single",
+        applied_scopes=["/subscriptions/subA"],
+    )
+    api_mock.return_value.reservation.list_all.return_value = iter([res])
+    with mock.patch.object(reservations,
+                           "_fetch_retail_reservation_rate",
+                           return_value=0.02):
+        rate = get_effective_storage_rate(
+            credential=mock.Mock(), subscription_id="subA",
+            region="eastus", redundancy="LRS", tier="Hot")
+    assert rate == 0.02
+
+
+def test_shared_scope_accepted(api_mock):
+    res = _Reservation(
+        sku_name="Blob_Storage_Reserved_Capacity_LRS_Hot_100TB",
+        applied_scope_type="Shared",
+        applied_scopes=[],
+    )
+    api_mock.return_value.reservation.list_all.return_value = iter([res])
+    with mock.patch.object(reservations,
+                           "_fetch_retail_reservation_rate",
+                           return_value=0.03):
+        rate = get_effective_storage_rate(
+            credential=mock.Mock(), subscription_id="subZ",
+            region="eastus", redundancy="LRS", tier="Hot")
+    assert rate == 0.03
+
+
+def test_managementgroup_scope_skipped(api_mock):
+    res = _Reservation(
+        sku_name="Blob_Storage_Reserved_Capacity_LRS_Hot_100TB",
+        applied_scope_type="ManagementGroup",
+        applied_scopes=["/providers/Microsoft.Management/managementGroups/mg1"],
+    )
+    api_mock.return_value.reservation.list_all.return_value = iter([res])
+    with mock.patch.object(reservations,
+                           "_fetch_retail_reservation_rate",
+                           return_value=0.99):
+        rate = get_effective_storage_rate(
+            credential=mock.Mock(), subscription_id="subA",
+            region="eastus", redundancy="LRS", tier="Hot")
+    assert rate is None
+
+
+# ---- never-throws contract --------------------------------------------
+
+def test_helper_never_throws_on_sdk_http_exception(api_mock, http_error):
+    api_mock.return_value.reservation.list_all.side_effect = (
+        http_error("boom"))
+    rate = get_effective_storage_rate(
+        credential=mock.Mock(), subscription_id="subA",
+        region="eastus", redundancy="LRS", tier="Hot")
+    assert rate is None
+
+
+def test_helper_never_throws_on_generic_exception(api_mock):
+    api_mock.return_value.reservation.list_all.side_effect = (
+        RuntimeError("kaboom"))
+    rate = get_effective_storage_rate(
+        credential=mock.Mock(), subscription_id="subA",
+        region="eastus", redundancy="LRS", tier="Hot")
+    assert rate is None

--- a/bumiworker/bumiworker/modules/azure_helpers/tests/test_sdk_signatures.py
+++ b/bumiworker/bumiworker/modules/azure_helpers/tests/test_sdk_signatures.py
@@ -1,0 +1,184 @@
+"""Lock Azure SDK client constructor signatures used by bumiworker helpers.
+
+The failure mode this file guards against: an SDK upgrade renames or
+reorders positional parameters, the caller silently passes the wrong
+value, the resulting HTTP call hits an invalid endpoint, the broad
+``except Exception`` in every helper swallows the error, and the
+recommendation run returns 0 rows.  The canonical example is
+``AzureReservationAPI(credential, subscription_id)`` where
+``subscription_id`` silently became ``base_url`` — ``list_all`` then
+targeted a malformed URL, returned nothing, and phantom over-savings
+figures were emitted for every tenant with Blob reservations.
+
+Each test function here imports the *real* SDK class (or skips if the
+package is absent), reads its ``__init__`` signature at runtime via
+``inspect``, and asserts the parameter contract our callers rely on.
+No fakes, no mocks — the whole point is to catch real SDK drift.
+
+Clients covered
+---------------
+* ``AzureReservationAPI``      (azure-mgmt-reservations)
+* ``MonitorManagementClient``  (azure-mgmt-monitor)
+* ``StorageManagementClient``  (azure-mgmt-storage)
+* ``ClientSecretCredential``   (azure-identity)
+"""
+import inspect
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# AzureReservationAPI
+# ---------------------------------------------------------------------------
+
+azure_mgmt_reservations = pytest.importorskip("azure.mgmt.reservations")
+
+
+def test_azure_reservation_api_ctor_signature():
+    """Guard the AzureReservationAPI(credential, base_url=None) contract.
+
+    Failure mode: if the SDK adds ``subscription_id`` as the second
+    positional parameter, any existing call of the form
+    ``AzureReservationAPI(credential)`` would silently stop working
+    because no parameter would be provided for the new slot, or a
+    future refactor might accidentally re-introduce the positional
+    ``subscription_id`` seen in the original bug where it was mistaken
+    for ``base_url``, causing ``reservation.list_all()`` to target an
+    invalid URL with errors swallowed by the broad ``except``.
+    """
+    from azure.mgmt.reservations import AzureReservationAPI
+
+    sig = inspect.signature(AzureReservationAPI.__init__)
+    params = list(sig.parameters)
+
+    # First positional after self must be credentials/credential.
+    assert params[1] in ("credentials", "credential"), (
+        f"AzureReservationAPI ctor first arg renamed: {params}. "
+        f"Update reservations.py caller and this assertion together."
+    )
+
+    # base_url must exist so the helper can rely on the default (None
+    # means the standard Azure endpoint).
+    assert "base_url" in params, (
+        f"AzureReservationAPI lost base_url kwarg: {params}. "
+        f"Review reservations.py — the helper depends on the SDK default."
+    )
+
+    # subscription_id must NOT be a constructor parameter.  This SDK is
+    # tenant-scoped; subscription filtering is done per-call.  If the SDK
+    # ever adds subscription_id here, callers must be audited to ensure
+    # they are not accidentally supplying it positionally as base_url.
+    assert "subscription_id" not in params, (
+        f"AzureReservationAPI ctor now takes subscription_id: {params}. "
+        f"Review azure_helpers/reservations.py — passing it positionally "
+        f"would silently override base_url and break list_all."
+    )
+
+
+# ---------------------------------------------------------------------------
+# MonitorManagementClient
+# ---------------------------------------------------------------------------
+
+azure_mgmt_monitor = pytest.importorskip("azure.mgmt.monitor")
+
+
+def test_monitor_management_client_ctor_signature():
+    """Guard the MonitorManagementClient(credential, subscription_id) contract.
+
+    Failure mode: the SDK reorders or renames positional args so that
+    ``subscription_id`` lands in the wrong slot, causing all metrics
+    queries to hit the wrong subscription or raise an auth error that is
+    swallowed by the broad ``except`` in metrics.py, resulting in every
+    storage account reporting 0 transactions and being incorrectly
+    flagged as a cold-tier candidate.
+    """
+    from azure.mgmt.monitor import MonitorManagementClient
+
+    sig = inspect.signature(MonitorManagementClient.__init__)
+    params = list(sig.parameters)
+
+    # First positional after self must be credentials/credential.
+    assert params[1] in ("credentials", "credential"), (
+        f"MonitorManagementClient ctor first arg renamed: {params}. "
+        f"Update metrics.py callers and this assertion together."
+    )
+
+    # Second positional must be subscription_id — metrics.py passes it
+    # as the second positional argument in every call site.
+    assert params[2] == "subscription_id", (
+        f"MonitorManagementClient ctor second arg is no longer "
+        f"subscription_id: {params}. metrics.py calls "
+        f"MonitorManagementClient(credential, subscription_id) — "
+        f"a rename or reorder here silently queries the wrong subscription."
+    )
+
+
+# ---------------------------------------------------------------------------
+# StorageManagementClient
+# ---------------------------------------------------------------------------
+
+azure_mgmt_storage = pytest.importorskip("azure.mgmt.storage")
+
+
+def test_storage_management_client_ctor_signature():
+    """Guard the StorageManagementClient(credential, subscription_id) contract.
+
+    Failure mode: same as MonitorManagementClient — if subscription_id
+    moves to a different positional slot, azure_cold_tier_candidates.py
+    would list storage accounts for the wrong subscription (or none),
+    and the broad ``except`` would swallow the error, producing an empty
+    recommendation run with no visible failure.
+    """
+    from azure.mgmt.storage import StorageManagementClient
+
+    sig = inspect.signature(StorageManagementClient.__init__)
+    params = list(sig.parameters)
+
+    # First positional after self must be credentials/credential.
+    assert params[1] in ("credentials", "credential"), (
+        f"StorageManagementClient ctor first arg renamed: {params}. "
+        f"Update azure_cold_tier_candidates.py caller and this assertion."
+    )
+
+    # Second positional must be subscription_id.
+    assert params[2] == "subscription_id", (
+        f"StorageManagementClient ctor second arg is no longer "
+        f"subscription_id: {params}. azure_cold_tier_candidates.py calls "
+        f"StorageManagementClient(credential, subscription_id) positionally."
+    )
+
+
+# ---------------------------------------------------------------------------
+# ClientSecretCredential
+# ---------------------------------------------------------------------------
+
+azure_identity = pytest.importorskip("azure.identity")
+
+
+def test_client_secret_credential_ctor_signature():
+    """Guard the ClientSecretCredential(tenant_id, client_id, client_secret) contract.
+
+    Failure mode: if the SDK renames or reorders these keyword arguments,
+    azure_helpers/credentials.py silently constructs an invalid credential
+    object.  Because ClientSecretCredential does not validate eagerly, the
+    error only surfaces when ``get_token`` is called inside the SDK, which
+    is then caught by the broad ``except`` in each helper, making the
+    entire cloud account appear to have no resources.
+    """
+    from azure.identity import ClientSecretCredential
+
+    sig = inspect.signature(ClientSecretCredential.__init__)
+    params = list(sig.parameters)
+
+    assert "tenant_id" in params, (
+        f"ClientSecretCredential lost tenant_id parameter: {params}. "
+        f"Update credentials.py make_credentials() and this assertion."
+    )
+    assert "client_id" in params, (
+        f"ClientSecretCredential lost client_id parameter: {params}. "
+        f"Update credentials.py make_credentials() and this assertion."
+    )
+    assert "client_secret" in params, (
+        f"ClientSecretCredential lost client_secret parameter: {params}. "
+        f"Update credentials.py make_credentials() and this assertion."
+    )


### PR DESCRIPTION
## Summary

Three review-ergonomics improvements distilled from PR #870 (azure cold-tier candidates) review experience:

1. **`AGENTS.md` at repo root** — Codex reads "Review guidelines" sections per OpenAI's GitHub-integration docs. Documents `unique_record_keys` override locations, reservation helper scope-filter semantics, and archive phantom-meta-field IRRELEVANT-fallthrough convention. Also includes existing repo conventions so any review agent has full context.

2. **`test_sdk_signatures.py`** — locks Azure SDK client constructor signatures (AzureReservationAPI, MonitorManagementClient, StorageManagementClient, ClientSecretCredential). Uses `inspect.signature` against the real SDK with `pytest.importorskip` for graceful absence. Catches future SDK upgrades that change positional/kwarg shapes silently.

3. **Cache-isolation black-box test** — strengthens the existing `test_cache_isolated_by_subscription_id` (which only proves cache miss) with a value-isolation assertion: subA's reserved rate must not bleed into subB's lookup, even when sharing region/redundancy/tier.

## Motivation

PR #870 went through 8 Codex review rounds. 3-4 of them were a re-flag of an already-present `unique_record_keys` override — Codex's analysis cached stale and failed to re-read the class header. AGENTS.md is the official mitigation (per OpenAI best-practices: "When Codex makes the same mistake twice, ask it for a retrospective and update AGENTS.md").

The two new tests close two regression vectors flagged on PR #870 (SDK ctor signature, cache cross-tenant bleed) so any future change that re-introduces them surfaces in CI rather than in a P1 review comment.

## No code-path changes

This PR adds tests and contributor docs only. Nothing in the recommendation runtime is modified.