### PR TITLE
feat(cloud_adapter): capture Azure storage account tier metadata

### DIFF
--- a/tools/cloud_adapter/clouds/azure.py
+++ b/tools/cloud_adapter/clouds/azure.py
@@ -1188,12 +1188,83 @@ class Azure(CloudBase):
         All of this may be confusing, it will be resolved in
         https://datatrendstech.atlassian.net/browse/OSB-646 and related epic
 
+        Augments the base BucketResource with Azure storage-account meta
+        used by tier-recommendation modules:
+        - access_tier / kind / sku_name / sku_tier — drives Premium and
+          archive-eligibility filters (Hot/Cool/Cold tiering applies only
+          to StorageV2/BlobStorage block blobs).
+        - is_hns_enabled / immutable_storage_with_versioning_enabled — flag
+          accounts where lifecycle moves are blocked or behave differently.
+        - last_access_time_tracking_enabled / is_versioning_enabled /
+          delete_retention_days — captured in one extra ARM call per
+          account (blob_services.get_service_properties). Tracking flag is
+          a precondition for cold/archive forecasts: when off, blobs have
+          no last-access timestamps and the signal is unreliable.
+        - lifecycle_policy_present — surfaced via management_policies.get;
+          informational only (existing policies are not assumed correct).
+
+        Adds 1–2 ARM read calls per account beyond the base list. Gated by
+        kind/sku.tier so premium/file-only accounts skip the blob_services
+        call entirely.
+
         :return: list(model.BucketResource)
         """
         accounts = self._retry(self.storage.storage_accounts.list)
         for account in accounts:
             tags = account.tags or {}
             cloud_console_link = self._generate_cloud_link(account.id)
+            info = self._parse_azure_id(account.id)
+            rg = info['group_name']
+            account_name = info['name']
+
+            kind = getattr(account, 'kind', None)
+            sku = getattr(account, 'sku', None)
+            sku_name = getattr(sku, 'name', None) if sku else None
+            sku_tier = getattr(sku, 'tier', None) if sku else None
+            access_tier = getattr(account, 'access_tier', None)
+            is_hns_enabled = getattr(account, 'is_hns_enabled', None)
+            immut = getattr(
+                account, 'immutable_storage_with_versioning', None)
+            immut_enabled = (
+                getattr(immut, 'enabled', None) if immut else None)
+
+            last_access_tracking = None
+            is_versioning = None
+            delete_retention = None
+            # Blob service properties only meaningful for block-blob-capable
+            # standard accounts. Skip premium / file-only kinds to avoid
+            # unnecessary ARM reads.
+            if (kind in ('StorageV2', 'BlobStorage')
+                    and sku_tier == 'Standard'):
+                try:
+                    bs_props = self._retry(
+                        self.storage.blob_services.get_service_properties,
+                        rg, account_name)
+                    lat_policy = getattr(
+                        bs_props, 'last_access_time_tracking_policy', None)
+                    if lat_policy is not None:
+                        last_access_tracking = getattr(
+                            lat_policy, 'enable', None)
+                    is_versioning = getattr(
+                        bs_props, 'is_versioning_enabled', None)
+                    drp = getattr(bs_props, 'delete_retention_policy', None)
+                    if drp is not None and getattr(drp, 'enabled', False):
+                        delete_retention = getattr(drp, 'days', None)
+                except (HttpResponseError, ResourceNotFoundError):
+                    pass
+
+            lifecycle_present = None
+            if kind in ('StorageV2', 'BlobStorage', 'BlockBlobStorage'):
+                try:
+                    self._retry(
+                        self.storage.management_policies.get,
+                        rg, account_name, 'default')
+                    lifecycle_present = True
+                except ResourceNotFoundError:
+                    lifecycle_present = False
+                except HttpResponseError:
+                    lifecycle_present = None
+
             res = BucketResource(
                 cloud_resource_id=account.id.lower(),
                 cloud_account_id=self.cloud_account_id,
@@ -1201,7 +1272,18 @@ class Azure(CloudBase):
                 organization_id=self.organization_id,
                 name=account.name,
                 tags=tags,
-                cloud_console_link=cloud_console_link)
+                cloud_console_link=cloud_console_link,
+                access_tier=access_tier,
+                kind=kind,
+                sku_name=sku_name,
+                sku_tier=sku_tier,
+                is_hns_enabled=is_hns_enabled,
+                immutable_storage_with_versioning_enabled=immut_enabled,
+                last_access_time_tracking_enabled=last_access_tracking,
+                is_versioning_enabled=is_versioning,
+                delete_retention_days=delete_retention,
+                lifecycle_policy_present=lifecycle_present,
+            )
             yield res
 
     def bucket_discovery_calls(self):

--- a/tools/cloud_adapter/model.py
+++ b/tools/cloud_adapter/model.py
@@ -267,6 +267,16 @@ class BucketResource(CloudResource):
                  'it_status_bucket',
                  'tiers',
                  'last_checked',
+                 'access_tier',
+                 'kind',
+                 'sku_name',
+                 'sku_tier',
+                 'is_hns_enabled',
+                 'immutable_storage_with_versioning_enabled',
+                 'last_access_time_tracking_enabled',
+                 'is_versioning_enabled',
+                 'delete_retention_days',
+                 'lifecycle_policy_present',
                 )
 
     def __init__(self,
@@ -284,6 +294,16 @@ class BucketResource(CloudResource):
                 it_status_bucket=None,
                 tiers=None,
                 last_checked=None,
+                access_tier=None,
+                kind=None,
+                sku_name=None,
+                sku_tier=None,
+                is_hns_enabled=None,
+                immutable_storage_with_versioning_enabled=None,
+                last_access_time_tracking_enabled=None,
+                is_versioning_enabled=None,
+                delete_retention_days=None,
+                lifecycle_policy_present=None,
                 **kwargs
             ):
         """
@@ -308,6 +328,22 @@ class BucketResource(CloudResource):
         - it_status_bucket (str|None): 'enabled' if IT applies to whole bucket
         - tiers (list): list of [display_name, size_gb] per storage tier
         - last_checked (list): dates strings when object GETs were observed
+        - access_tier (str|None): Azure account-default access tier
+            ("Hot"|"Cool"|"Cold"|"Premium"); None for kinds that do not
+            expose tiering.
+        - kind (str|None): Azure account kind
+            ("StorageV2"|"BlobStorage"|"Storage"|"FileStorage"|"BlockBlobStorage")
+        - sku_name (str|None): Azure SKU name (e.g. "Standard_LRS")
+        - sku_tier (str|None): Azure SKU tier ("Standard"|"Premium")
+        - is_hns_enabled (bool|None): Hierarchical namespace flag (Data Lake Gen2)
+        - immutable_storage_with_versioning_enabled (bool|None): WORM gate
+        - last_access_time_tracking_enabled (bool|None): account-level
+            tracking policy flag; without it enabled, blobs have no
+            last-access timestamps so cold/archive forecasts are unreliable
+        - is_versioning_enabled (bool|None): blob versioning state
+        - delete_retention_days (int|None): soft-delete retention in days
+        - lifecycle_policy_present (bool|None): True if a default lifecycle
+            management policy exists on the account
         """
         super().__init__(**kwargs)
         self.name = name
@@ -325,6 +361,18 @@ class BucketResource(CloudResource):
         self.it_status_bucket = it_status_bucket
         self.tiers = tiers or []
         self.last_checked = last_checked or []
+        self.access_tier = access_tier
+        self.kind = kind
+        self.sku_name = sku_name
+        self.sku_tier = sku_tier
+        self.is_hns_enabled = is_hns_enabled
+        self.immutable_storage_with_versioning_enabled = (
+            immutable_storage_with_versioning_enabled
+        )
+        self.last_access_time_tracking_enabled = last_access_time_tracking_enabled
+        self.is_versioning_enabled = is_versioning_enabled
+        self.delete_retention_days = delete_retention_days
+        self.lifecycle_policy_present = lifecycle_policy_present
 
     def __repr__(self):
         return (
@@ -361,6 +409,18 @@ class BucketResource(CloudResource):
             'it_status_bucket': self.it_status_bucket,
             'tiers': self.tiers,
             'last_checked': self.last_checked,
+            'access_tier': self.access_tier,
+            'kind': self.kind,
+            'sku_name': self.sku_name,
+            'sku_tier': self.sku_tier,
+            'is_hns_enabled': self.is_hns_enabled,
+            'immutable_storage_with_versioning_enabled':
+                self.immutable_storage_with_versioning_enabled,
+            'last_access_time_tracking_enabled':
+                self.last_access_time_tracking_enabled,
+            'is_versioning_enabled': self.is_versioning_enabled,
+            'delete_retention_days': self.delete_retention_days,
+            'lifecycle_policy_present': self.lifecycle_policy_present,
         })
         return meta
 

--- a/tools/cloud_adapter/tests/test_azure_storage_discovery.py
+++ b/tools/cloud_adapter/tests/test_azure_storage_discovery.py
@@ -10,22 +10,44 @@ The discovery layer captures meta used by downstream tier-recommendation
 modules (cold/archive). When the SDK renames a field, those modules
 silently lose signal — these locks force the rename to surface as a
 test failure during dependency bumps.
+
+Implementation note: ``azure-mgmt`` models split fields into two groups:
+- writable / client-supplied → present in ``__init__`` parameters
+- server-populated read-only (e.g. ``StorageAccount.access_tier``,
+  ``Sku.tier``) → present only in ``_attribute_map``
+
+Discovery reads server-populated fields via ``getattr``, so these locks
+introspect ``_attribute_map`` rather than the constructor signature.
 """
 import inspect
 
 import pytest
 
 
+def _attribute_map(cls):
+    """Return the SDK model's `_attribute_map` keys as a set.
+
+    `_attribute_map` is the ``msrest``-style declaration of every
+    serialized field on the model — both writable and read-only — so
+    this is the right surface to assert against for fields populated
+    by the service rather than the caller.
+    """
+    return set(getattr(cls, '_attribute_map', {}).keys())
+
+
 def test_storage_account_exposes_tier_fields():
     """``StorageAccount`` exposes the fields ``discover_bucket_resources``
     reads via ``getattr``: access_tier, kind, sku, is_hns_enabled,
     immutable_storage_with_versioning.
+
+    ``access_tier``, ``kind`` and ``sku`` are server-populated read-only
+    properties — they live in ``_attribute_map`` but not in
+    ``__init__``. ``is_hns_enabled`` and ``immutable_storage_with_versioning``
+    are caller-supplied at create-time AND surfaced on read; both maps
+    list them.
     """
     models = pytest.importorskip("azure.mgmt.storage.models")
-    cls = models.StorageAccount
-
-    init_sig = inspect.signature(cls.__init__)
-    params = set(init_sig.parameters.keys())
+    fields = _attribute_map(models.StorageAccount)
 
     expected = {
         'access_tier',
@@ -34,7 +56,7 @@ def test_storage_account_exposes_tier_fields():
         'is_hns_enabled',
         'immutable_storage_with_versioning',
     }
-    missing = expected - params
+    missing = expected - fields
     assert not missing, (
         f"StorageAccount missing expected fields: {missing}. "
         f"Discovery in tools/cloud_adapter/clouds/azure.py reads these "
@@ -64,15 +86,18 @@ def test_sku_exposes_name_and_tier():
     """``Sku.name`` (e.g. Standard_LRS) and ``Sku.tier`` (Standard /
     Premium) are read by the discovery layer to filter premium accounts
     out of cold/archive recommendations.
+
+    ``Sku.tier`` is a read-only / server-populated property in this
+    SDK version — present in ``_attribute_map`` but not in
+    ``__init__``. ``Sku.name`` is caller-supplied and listed in both.
     """
     models = pytest.importorskip("azure.mgmt.storage.models")
     cls = getattr(models, 'Sku', None)
     assert cls is not None, "Sku model missing from SDK"
 
-    init_sig = inspect.signature(cls.__init__)
-    params = set(init_sig.parameters.keys())
-    assert 'name' in params, "Sku.name missing — premium filter breaks"
-    assert 'tier' in params, "Sku.tier missing — premium filter breaks"
+    fields = _attribute_map(cls)
+    assert 'name' in fields, "Sku.name missing — premium filter breaks"
+    assert 'tier' in fields, "Sku.tier missing — premium filter breaks"
 
 
 def test_blob_service_properties_exposes_tracking_policy():
@@ -85,15 +110,13 @@ def test_blob_service_properties_exposes_tracking_policy():
     cls = getattr(models, 'BlobServiceProperties', None)
     assert cls is not None, "BlobServiceProperties missing from SDK"
 
-    init_sig = inspect.signature(cls.__init__)
-    params = set(init_sig.parameters.keys())
-
+    fields = _attribute_map(cls)
     expected = {
         'last_access_time_tracking_policy',
         'is_versioning_enabled',
         'delete_retention_policy',
     }
-    missing = expected - params
+    missing = expected - fields
     assert not missing, (
         f"BlobServiceProperties missing expected fields: {missing}. "
         f"discover_bucket_resources reads these to populate the "
@@ -110,9 +133,8 @@ def test_last_access_time_tracking_policy_enable_field():
     cls = getattr(models, 'LastAccessTimeTrackingPolicy', None)
     assert cls is not None, "LastAccessTimeTrackingPolicy missing from SDK"
 
-    init_sig = inspect.signature(cls.__init__)
-    params = set(init_sig.parameters.keys())
-    assert 'enable' in params, (
+    fields = _attribute_map(cls)
+    assert 'enable' in fields, (
         "LastAccessTimeTrackingPolicy.enable missing — tracking-gate breaks."
     )
 
@@ -123,9 +145,8 @@ def test_delete_retention_policy_fields():
     cls = getattr(models, 'DeleteRetentionPolicy', None)
     assert cls is not None, "DeleteRetentionPolicy missing from SDK"
 
-    init_sig = inspect.signature(cls.__init__)
-    params = set(init_sig.parameters.keys())
-    assert {'enabled', 'days'}.issubset(params), (
+    fields = _attribute_map(cls)
+    assert {'enabled', 'days'}.issubset(fields), (
         "DeleteRetentionPolicy.enabled / .days missing — soft-delete "
         "metadata capture breaks."
     )
@@ -139,9 +160,8 @@ def test_immutable_storage_with_versioning_enabled_field():
         "ImmutableStorageAccount missing from SDK — WORM detection breaks."
     )
 
-    init_sig = inspect.signature(cls.__init__)
-    params = set(init_sig.parameters.keys())
-    assert 'enabled' in params, (
+    fields = _attribute_map(cls)
+    assert 'enabled' in fields, (
         "ImmutableStorageAccount.enabled missing — WORM gate breaks."
     )
 
@@ -149,15 +169,17 @@ def test_immutable_storage_with_versioning_enabled_field():
 def test_blob_services_operations_present():
     """``StorageManagementClient`` exposes ``blob_services`` and
     ``management_policies`` operation groups used by discovery.
+
+    Operations groups are attached at construction; we probe for the
+    operation classes in the operations module rather than instantiating
+    a client (which requires credentials).
     """
     storage_module = pytest.importorskip("azure.mgmt.storage")
     client_cls = getattr(storage_module, 'StorageManagementClient', None)
     assert client_cls is not None, "StorageManagementClient missing"
+    # Reference the constructor so a radical SDK rewrite still surfaces.
+    assert inspect.signature(client_cls.__init__) is not None
 
-    init_sig = inspect.signature(client_cls.__init__)
-    # Operations groups are attached at construction; we can't easily
-    # introspect without an instance, so probe for the operations
-    # classes in the operations module.
     ops_module = pytest.importorskip("azure.mgmt.storage.operations")
     assert hasattr(ops_module, 'BlobServicesOperations'), (
         "BlobServicesOperations missing — extra blob-service properties "
@@ -167,6 +189,3 @@ def test_blob_services_operations_present():
         "ManagementPoliciesOperations missing — lifecycle-policy detection "
         "in discover_bucket_resources breaks."
     )
-    # Reference init_sig to keep the introspection live; if SDK shape
-    # changes radically, signature check provides a fallback alarm.
-    assert init_sig is not None

--- a/tools/cloud_adapter/tests/test_azure_storage_discovery.py
+++ b/tools/cloud_adapter/tests/test_azure_storage_discovery.py
@@ -1,0 +1,172 @@
+"""SDK signature locks for the Azure storage discovery path.
+
+These tests pin the attribute names that
+``tools/cloud_adapter/clouds/azure.py``'s ``discover_bucket_resources``
+relies on. They run offline (no Azure API calls) and exist to fail
+loudly if a future ``azure-mgmt-storage`` upgrade renames or removes a
+field we depend on.
+
+The discovery layer captures meta used by downstream tier-recommendation
+modules (cold/archive). When the SDK renames a field, those modules
+silently lose signal — these locks force the rename to surface as a
+test failure during dependency bumps.
+"""
+import inspect
+
+import pytest
+
+
+def test_storage_account_exposes_tier_fields():
+    """``StorageAccount`` exposes the fields ``discover_bucket_resources``
+    reads via ``getattr``: access_tier, kind, sku, is_hns_enabled,
+    immutable_storage_with_versioning.
+    """
+    models = pytest.importorskip("azure.mgmt.storage.models")
+    cls = models.StorageAccount
+
+    init_sig = inspect.signature(cls.__init__)
+    params = set(init_sig.parameters.keys())
+
+    expected = {
+        'access_tier',
+        'kind',
+        'sku',
+        'is_hns_enabled',
+        'immutable_storage_with_versioning',
+    }
+    missing = expected - params
+    assert not missing, (
+        f"StorageAccount missing expected fields: {missing}. "
+        f"Discovery in tools/cloud_adapter/clouds/azure.py reads these "
+        f"via getattr; an SDK rename would silently null them."
+    )
+
+
+def test_access_tier_enum_values():
+    """``AccessTier`` enum carries the values our recommendation modules
+    pattern-match on. Premium is account-default for BlockBlobStorage;
+    Archive is per-blob only and intentionally absent here.
+    """
+    models = pytest.importorskip("azure.mgmt.storage.models")
+    enum_cls = getattr(models, 'AccessTier', None)
+    assert enum_cls is not None, "AccessTier enum missing from SDK"
+
+    values = {str(v.value).lower() for v in enum_cls}
+    expected = {'hot', 'cool', 'cold', 'premium'}
+    missing = expected - values
+    assert not missing, (
+        f"AccessTier missing expected values: {missing}. "
+        f"Premium signals BlockBlobStorage; Cold gates cold-tier recs."
+    )
+
+
+def test_sku_exposes_name_and_tier():
+    """``Sku.name`` (e.g. Standard_LRS) and ``Sku.tier`` (Standard /
+    Premium) are read by the discovery layer to filter premium accounts
+    out of cold/archive recommendations.
+    """
+    models = pytest.importorskip("azure.mgmt.storage.models")
+    cls = getattr(models, 'Sku', None)
+    assert cls is not None, "Sku model missing from SDK"
+
+    init_sig = inspect.signature(cls.__init__)
+    params = set(init_sig.parameters.keys())
+    assert 'name' in params, "Sku.name missing — premium filter breaks"
+    assert 'tier' in params, "Sku.tier missing — premium filter breaks"
+
+
+def test_blob_service_properties_exposes_tracking_policy():
+    """``BlobServiceProperties`` exposes the fields captured by the
+    extra ``blob_services.get_service_properties`` call:
+    last_access_time_tracking_policy, is_versioning_enabled,
+    delete_retention_policy.
+    """
+    models = pytest.importorskip("azure.mgmt.storage.models")
+    cls = getattr(models, 'BlobServiceProperties', None)
+    assert cls is not None, "BlobServiceProperties missing from SDK"
+
+    init_sig = inspect.signature(cls.__init__)
+    params = set(init_sig.parameters.keys())
+
+    expected = {
+        'last_access_time_tracking_policy',
+        'is_versioning_enabled',
+        'delete_retention_policy',
+    }
+    missing = expected - params
+    assert not missing, (
+        f"BlobServiceProperties missing expected fields: {missing}. "
+        f"discover_bucket_resources reads these to populate the "
+        f"last-access-tracking gate used by tier-recommendation modules."
+    )
+
+
+def test_last_access_time_tracking_policy_enable_field():
+    """``LastAccessTimeTrackingPolicy.enable`` is the bool used as the
+    cold/archive forecaster precondition. Without it on, blobs have no
+    last-access timestamps and recommendations would run on noise.
+    """
+    models = pytest.importorskip("azure.mgmt.storage.models")
+    cls = getattr(models, 'LastAccessTimeTrackingPolicy', None)
+    assert cls is not None, "LastAccessTimeTrackingPolicy missing from SDK"
+
+    init_sig = inspect.signature(cls.__init__)
+    params = set(init_sig.parameters.keys())
+    assert 'enable' in params, (
+        "LastAccessTimeTrackingPolicy.enable missing — tracking-gate breaks."
+    )
+
+
+def test_delete_retention_policy_fields():
+    """``DeleteRetentionPolicy`` exposes ``enabled`` and ``days``."""
+    models = pytest.importorskip("azure.mgmt.storage.models")
+    cls = getattr(models, 'DeleteRetentionPolicy', None)
+    assert cls is not None, "DeleteRetentionPolicy missing from SDK"
+
+    init_sig = inspect.signature(cls.__init__)
+    params = set(init_sig.parameters.keys())
+    assert {'enabled', 'days'}.issubset(params), (
+        "DeleteRetentionPolicy.enabled / .days missing — soft-delete "
+        "metadata capture breaks."
+    )
+
+
+def test_immutable_storage_with_versioning_enabled_field():
+    """``ImmutableStorageAccount.enabled`` is the WORM gate flag."""
+    models = pytest.importorskip("azure.mgmt.storage.models")
+    cls = getattr(models, 'ImmutableStorageAccount', None)
+    assert cls is not None, (
+        "ImmutableStorageAccount missing from SDK — WORM detection breaks."
+    )
+
+    init_sig = inspect.signature(cls.__init__)
+    params = set(init_sig.parameters.keys())
+    assert 'enabled' in params, (
+        "ImmutableStorageAccount.enabled missing — WORM gate breaks."
+    )
+
+
+def test_blob_services_operations_present():
+    """``StorageManagementClient`` exposes ``blob_services`` and
+    ``management_policies`` operation groups used by discovery.
+    """
+    storage_module = pytest.importorskip("azure.mgmt.storage")
+    client_cls = getattr(storage_module, 'StorageManagementClient', None)
+    assert client_cls is not None, "StorageManagementClient missing"
+
+    init_sig = inspect.signature(client_cls.__init__)
+    # Operations groups are attached at construction; we can't easily
+    # introspect without an instance, so probe for the operations
+    # classes in the operations module.
+    ops_module = pytest.importorskip("azure.mgmt.storage.operations")
+    assert hasattr(ops_module, 'BlobServicesOperations'), (
+        "BlobServicesOperations missing — extra blob-service properties "
+        "call in discover_bucket_resources breaks."
+    )
+    assert hasattr(ops_module, 'ManagementPoliciesOperations'), (
+        "ManagementPoliciesOperations missing — lifecycle-policy detection "
+        "in discover_bucket_resources breaks."
+    )
+    # Reference init_sig to keep the introspection live; if SDK shape
+    # changes radically, signature check provides a fallback alarm.
+    assert init_sig is not None


### PR DESCRIPTION
## Summary

Discovery-layer change: capture Azure storage account tier metadata on `BucketResource` so downstream tier-recommendation modules (cold/archive) can read account state without re-querying Azure.

## What

`tools/cloud_adapter/clouds/azure.py` `discover_bucket_resources` now reads:

- **From `storage_accounts.list()` (existing call)**: `access_tier`, `kind`, `sku.name`, `sku.tier`, `is_hns_enabled`, `immutable_storage_with_versioning.enabled`.
- **From `blob_services.get_service_properties()` (new — 1 ARM call per account, gated to `kind ∈ {StorageV2, BlobStorage}` + `sku.tier == Standard`)**: `last_access_time_tracking_policy.enable`, `is_versioning_enabled`, `delete_retention_policy.{enabled,days}`.
- **From `management_policies.get(rg, name, "default")` (new — 1 ARM call per account, try/except `ResourceNotFoundError`, gated to block-blob-capable kinds)**: lifecycle policy presence (boolean only — content not captured).

Total ARM cost: 1 + up to 2N reads per discovery cycle, where N = storage account count. Premium and file-only accounts skip the blob-services call.

`tools/cloud_adapter/model.py` `BucketResource` extended with matching slots, ctor params, and meta dict entries:

```
access_tier, kind, sku_name, sku_tier,
is_hns_enabled, immutable_storage_with_versioning_enabled,
last_access_time_tracking_enabled, is_versioning_enabled,
delete_retention_days, lifecycle_policy_present
```

`tools/cloud_adapter/tests/test_azure_storage_discovery.py` (new): SDK signature locks via `_attribute_map` introspection for `StorageAccount`, `Sku`, `BlobServiceProperties`, `LastAccessTimeTrackingPolicy`, `DeleteRetentionPolicy`, `ImmutableStorageAccount`, plus `AccessTier` enum value coverage and presence of `BlobServicesOperations` / `ManagementPoliciesOperations` on the management client. Uses `pytest.importorskip` so the suite degrades gracefully when the SDK is absent. `_attribute_map` is the right surface (rather than `__init__`) because several fields the discovery layer reads (`access_tier`, `kind`, `sku`, `Sku.tier`) are server-populated read-only properties that intentionally do not appear in the constructor signature.

## Why

Two downstream consumers need this metadata:

1. **Cold-tier archive module** falls through to `RECOMMENDATION_IRRELEVANT` for every prior cold-tier optimization because it cannot read the live access tier off the resource document. Once this lands, that branch can compare `meta.access_tier` to the optimization's `target_tier` and emit `RECOMMENDATION_APPLIED` accurately. Caveat: comparison is at account-default granularity; per-blob tier overrides require a data-plane scan and remain out of scope.

2. **Future archive-tier-candidates module** needs `kind` / `sku_tier` to filter premium accounts (no Hot/Cool/Cold tiering), `last_access_time_tracking_enabled` as a forecaster precondition (without it, blobs have no last-access timestamps and signal is unreliable), and `immutable_storage_with_versioning_enabled` to skip WORM-locked accounts.

Discovery-layer scope only — no recommendation modules are modified here. Follow-up PRs will consume the new fields.

## Notes for reviewers

- Premium accounts (`kind ∈ {BlockBlobStorage, FileStorage}`) carry `access_tier == "Premium"` per the Azure SDK enum; `Archive` is NOT a valid account-level value (per-blob only) and intentionally absent from the test enum coverage.
- `management_policies.get` raises `ResourceNotFoundError` when no policy exists; we treat that as `lifecycle_policy_present = False` rather than `None`.
- Existing buckets discovered before this change will populate the new fields on the next discovery cycle. Until then, downstream modules see `None` and should treat it as "unknown" (defensive default).
- Test file uses `pytest.importorskip` rather than hard imports so suites without `azure-mgmt-storage` installed are unaffected.

## Test plan

- [x] AST parse check on both modified Python files.
- [x] All 8 SDK signature lock tests pass against `azure-mgmt-storage==24.0.1` locally.
- [ ] Live discovery smoke against an Azure organization: confirm `meta.access_tier`, `kind`, `sku_name`, `last_access_time_tracking_enabled` populate on existing bucket resources after a discovery cycle.
- [ ] Verify `management_policies.get` `ResourceNotFoundError` path on an account with no lifecycle policy (most accounts).