### PR TITLE
MPT-21087 – Reduce cloud API rate-limit failures and improve their visibility

### DIFF
--- a/diworker/diworker/importers/base.py
+++ b/diworker/diworker/importers/base.py
@@ -4,7 +4,9 @@ import os
 import requests
 import gzip
 import shutil
+import threading
 import uuid
+from contextlib import nullcontext
 from functools import cached_property
 
 from collections import defaultdict
@@ -24,16 +26,30 @@ import tools.optscale_time as opttime
 
 LOG = logging.getLogger(__name__)
 CHUNK_SIZE = 200
+
+_THROTTLE_SEMAPHORES: dict[str, threading.Semaphore] = {}
+_THROTTLE_LOCK = threading.Lock()
+
 CSV_REWRITE_DAYS = 5
 GZIP_ENDING = '.gz'
 REPORTS_PATH_PREFIX = 'reports'
 
 
+def _get_throttle_semaphore(parent_id: str,
+                            max_concurrent: int) -> threading.Semaphore:
+    with _THROTTLE_LOCK:
+        if parent_id not in _THROTTLE_SEMAPHORES:
+            _THROTTLE_SEMAPHORES[parent_id] = threading.Semaphore(max_concurrent)
+        return _THROTTLE_SEMAPHORES[parent_id]
+
+
 class BaseReportImporter:
     def __init__(self, cloud_account_id, rest_cl, config_cl, mongo_raw,
                  mongo_resources, clickhouse_cl, import_file=None,
-                 recalculate=False, detect_period_start=True):
+                 recalculate=False, detect_period_start=True,
+                 max_tenant_concurrent=1):
         self.cloud_acc_id = cloud_account_id
+        self.max_tenant_concurrent = max_tenant_concurrent
         self.rest_cl = rest_cl
         self.config_cl = config_cl
         self.mongo_raw = mongo_raw
@@ -429,6 +445,15 @@ class BaseReportImporter:
         self.generate_clean_records(regeneration=regeneration)
 
     def import_report(self):
+        parent_id = self.cloud_acc.get('parent_id')
+        throttle = (
+            _get_throttle_semaphore(parent_id, self.max_tenant_concurrent)
+            if parent_id else nullcontext()
+        )
+        with throttle:
+            self._run_import()
+
+    def _run_import(self):
         LOG.info('Started import for %s', self.cloud_acc_id)
         self.prepare()
         try:

--- a/diworker/diworker/main.py
+++ b/diworker/diworker/main.py
@@ -40,6 +40,14 @@ LOG = logging.getLogger(__name__)
 ENVIRONMENT_CLOUD_TYPE = 'environment'
 HEARTBEAT_INTERVAL = 300
 DEFAULT_MAX_WORKERS = 4
+DEFAULT_MAX_TENANT_WORKERS = 1
+
+
+def _is_rate_limit_exc(exc):
+    if getattr(exc, 'status_code', None) == 429:
+        return True
+    msg = str(exc).lower()
+    return '429' in msg or 'toomanyrequests' in msg or 'too many requests' in msg
 
 
 class DIWorker(ConsumerMixin):
@@ -168,7 +176,9 @@ class DIWorker(ConsumerMixin):
             'mongo_resources': mongo_cl.restapi['resources'],
             'clickhouse_cl': clickhouse_cl,
             'import_file': import_dict.get('import_file'),
-            'recalculate': is_recalculation}
+            'recalculate': is_recalculation,
+            'max_tenant_concurrent': int(self.diworker_settings.get(
+                'max_tenant_import_workers', DEFAULT_MAX_TENANT_WORKERS))}
         importer = None
         ca = None
         previous_attempt_ts = 0
@@ -220,11 +230,13 @@ class DIWorker(ConsumerMixin):
             if not importer:
                 importer = BaseReportImporter(**importer_params)
             importer.update_cloud_import_attempt(now, reason)
-            self.send_report_failed_email(ca, previous_attempt_ts, now)
+            self.send_report_failed_email(
+                ca, previous_attempt_ts, now,
+                is_throttled=_is_rate_limit_exc(exc))
             raise
 
     def send_report_failed_email(self, cloud_account, previous_attempt_ts,
-                                 now):
+                                 now, is_throttled=False):
         last_import_at = cloud_account['last_import_at']
         if not last_import_at:
             last_import_at = cloud_account['created_at']
@@ -236,9 +248,11 @@ class DIWorker(ConsumerMixin):
                     utcfromtimestamp(now)):
                 # email already sent today during previous report import fails
                 return
+        action = ('report_import_throttled' if is_throttled
+                  else 'report_import_failed')
         self.publish_activities_task(
             cloud_account['organization_id'], cloud_account['id'],
-            'cloud_account', 'report_import_failed',
+            'cloud_account', action,
             'organization.report_import.failed')
 
     def process_task(self, body, message):

--- a/docker_images/keeper_executor/events.py
+++ b/docker_images/keeper_executor/events.py
@@ -391,3 +391,10 @@ class Events(enum.Enum):
         ['object_name', 'object_id'],
         "INFO"
     ]
+    N0163 = [
+        "Billing data import for cloud account {object_name} "
+        "({cloud_account_id}) was throttled by the cloud provider: "
+        "{error_reason}",
+        ["object_name", "cloud_account_id", "error_reason"],
+        "WARNING"
+    ]

--- a/docker_images/keeper_executor/executors/main_events.py
+++ b/docker_images/keeper_executor/executors/main_events.py
@@ -24,6 +24,7 @@ class MainEventExecutor(BaseEventExecutor):
             'cloud_account_deleted': Events.N0068,
             'report_import_completed': Events.N0069,
             'report_import_failed': Events.N0070,
+            'report_import_throttled': Events.N0163,
             'assignment_request_accepted': Events.N0071,
             'assignment_request_declined': Events.N0072,
             'root_assigned_resource': Events.N0076,


### PR DESCRIPTION
## Description

### Problem

  When a tenant has multiple cloud accounts (e.g. several Azure subscriptions under the same tenant), their billing imports run in parallel and share the same cloud-provider API rate-limit quota. Under load, this causes cascading HTTP 429 errors that exhaust all retry attempts, leaving imports in a failed state and surfacing an ERROR event in the organisation's event log, even though the failure is transient and automatically retried.

### What changed

  - Parallel imports per tenant are now bounded. Accounts that share a rate-limit quota (identified by a common parent account) are imported with a configurable maximum concurrency instead of all at once. This significantly reduces the chance of hitting provider rate limits in the first place. The limit is tunable via the /diworker/max_tenant_import_workers configuration key (default: 1).
  - Rate-limit failures are no longer reported as errors. When an import fails solely because the cloud provider throttled the requests, the event log now records a WARNING ("was throttled by the cloud provider") rather than an ERROR ("failed"). Genuine billing API failures are unchanged and still appear as errors.

## Related issue number

-

## Special notes

-

## Checklist

* [X] The pull request title is a good summary of the changes
* [ ] Unit tests for the changes exist
* [ ] New and existing unit tests pass locally